### PR TITLE
Fix: canonizing of literal data for encrypted messages

### DIFF
--- a/openpgp/end_to_end_test.go
+++ b/openpgp/end_to_end_test.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"time"
 	"io"
+
 )
 
 type algorithmSet struct {
@@ -275,7 +276,7 @@ func signVerifyTest(t *testing.T, testSetFrom algorithmSet, privateKeyFrom Entit
 	signatureReader := bytes.NewReader(buf.Bytes())
 
 	wrongmessage := bytes.NewReader(bytes.NewBufferString("testing 漢字").Bytes())
-	wrongsigner, err := CheckArmoredDetachedSignature(publicKeyFrom, wrongmessage, signatureReader)
+	wrongsigner, err := CheckArmoredDetachedSignature(publicKeyFrom, wrongmessage, signatureReader, nil)
 
 	if err == nil || wrongsigner != nil {
 		t.Fatal("Expected the signature to not verify")
@@ -286,7 +287,7 @@ func signVerifyTest(t *testing.T, testSetFrom algorithmSet, privateKeyFrom Entit
 	signatureReader.Seek(0, io.SeekStart)
 
 	wronglineendings := bytes.NewReader(bytes.NewBufferString("testing 漢字 \n \r\n \n").Bytes())
-	wronglinesigner, err := CheckArmoredDetachedSignature(publicKeyFrom, wronglineendings, signatureReader)
+	wronglinesigner, err := CheckArmoredDetachedSignature(publicKeyFrom, wronglineendings, signatureReader, nil)
 
 	if (binary) {
 		if err == nil || wronglinesigner != nil {
@@ -310,7 +311,7 @@ func signVerifyTest(t *testing.T, testSetFrom algorithmSet, privateKeyFrom Entit
 	message.Seek(0, io.SeekStart)
 	signatureReader.Seek(0, io.SeekStart)
 
-	signer, err := CheckArmoredDetachedSignature(publicKeyFrom, message, signatureReader)
+	signer, err := CheckArmoredDetachedSignature(publicKeyFrom, message, signatureReader, nil)
 
 	if err != nil {
 		t.Errorf("signature error: %s", err)

--- a/openpgp/errors/errors.go
+++ b/openpgp/errors/errors.go
@@ -41,6 +41,14 @@ func (b SignatureError) Error() string {
 	return "openpgp: invalid signature: " + string(b)
 }
 
+type signatureExpiredError int
+
+func (se signatureExpiredError) Error() string {
+	return "openpgp: signature expired"
+}
+
+var ErrSignatureExpired error = signatureExpiredError(0)
+
 type keyIncorrectError int
 
 func (ki keyIncorrectError) Error() string {

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -479,7 +479,6 @@ func (sig *Signature) KeyExpired(currentTime time.Time) bool {
 	if sig.CreationTime.After(currentTime) {
 		return false
 	}
-	// TODO: also check for time in future!
 	if sig.KeyLifetimeSecs == nil {
 		return false
 	}

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -477,7 +477,7 @@ func serializeSubpackets(to []byte, subpackets []outputSubpacket, hashed bool) {
 // expired or is signed in the future.
 func (sig *Signature) KeyExpired(currentTime time.Time) bool {
 	if sig.CreationTime.After(currentTime) {
-		return false
+		return true
 	}
 	if sig.KeyLifetimeSecs == nil {
 		return false

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -474,8 +474,12 @@ func serializeSubpackets(to []byte, subpackets []outputSubpacket, hashed bool) {
 }
 
 // KeyExpired returns whether sig is a self-signature of a key that has
-// expired.
+// expired or is signed in the future.
 func (sig *Signature) KeyExpired(currentTime time.Time) bool {
+	if sig.CreationTime.After(currentTime) {
+		return false
+	}
+	// TODO: also check for time in future!
 	if sig.KeyLifetimeSecs == nil {
 		return false
 	}

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -420,7 +420,7 @@ func CheckDetachedSignature(keyring KeyRing, signed, signature io.Reader, config
 		switch sig := p.(type) {
 		case *packet.Signature:
 			err = key.PublicKey.VerifySignature(h, sig)
-			if err == nil && !sig.KeyExpired(config.Now()) {
+			if err == nil && sig.KeyExpired(config.Now()) {
 				err = errors.ErrSignatureExpired
 			}
 		case *packet.SignatureV3:

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -136,7 +136,7 @@ ParsePackets:
 				return nil, errors.StructuralError("key material not followed by encrypted message")
 			}
 			packets.Unread(p)
-			return readSignedMessage(packets, nil, keyring)
+			return readSignedMessage(packets, nil, keyring, config)
 		}
 	}
 
@@ -216,13 +216,13 @@ FindKey:
 	if err := packets.Push(decrypted); err != nil {
 		return nil, err
 	}
-	return readSignedMessage(packets, md, keyring)
+	return readSignedMessage(packets, md, keyring, config)
 }
 
 // readSignedMessage reads a possibly signed message if mdin is non-zero then
 // that structure is updated and returned. Otherwise a fresh MessageDetails is
 // used.
-func readSignedMessage(packets *packet.Reader, mdin *MessageDetails, keyring KeyRing) (md *MessageDetails, err error) {
+func readSignedMessage(packets *packet.Reader, mdin *MessageDetails, keyring KeyRing, config *packet.Config) (md *MessageDetails, err error) {
 	if mdin == nil {
 		mdin = new(MessageDetails)
 	}
@@ -266,7 +266,7 @@ FindLiteralData:
 	}
 
 	if md.SignedBy != nil {
-		md.UnverifiedBody = &signatureCheckReader{packets, h, wrappedHash, md}
+		md.UnverifiedBody = &signatureCheckReader{packets, h, wrappedHash, md, config}
 	} else if md.decrypted != nil {
 		md.UnverifiedBody = checkReader{md}
 	} else {
@@ -322,6 +322,7 @@ type signatureCheckReader struct {
 	packets        *packet.Reader
 	h, wrappedHash hash.Hash
 	md             *MessageDetails
+	config         *packet.Config
 }
 
 func (scr *signatureCheckReader) Read(buf []byte) (n int, err error) {
@@ -337,6 +338,9 @@ func (scr *signatureCheckReader) Read(buf []byte) (n int, err error) {
 		var ok bool
 		if scr.md.Signature, ok = p.(*packet.Signature); ok {
 			scr.md.SignatureError = scr.md.SignedBy.PublicKey.VerifySignature(scr.h, scr.md.Signature)
+			if scr.md.SignatureError == nil && scr.md.Signature.KeyExpired(scr.config.Now()) {
+				scr.md.SignatureError = errors.ErrSignatureExpired
+			}
 		} else if scr.md.SignatureV3, ok = p.(*packet.SignatureV3); ok {
 			scr.md.SignatureError = scr.md.SignedBy.PublicKey.VerifySignatureV3(scr.h, scr.md.SignatureV3)
 		} else {
@@ -360,7 +364,7 @@ func (scr *signatureCheckReader) Read(buf []byte) (n int, err error) {
 // CheckDetachedSignature takes a signed file and a detached signature and
 // returns the signer if the signature is valid. If the signer isn't known,
 // ErrUnknownIssuer is returned.
-func CheckDetachedSignature(keyring KeyRing, signed, signature io.Reader) (signer *Entity, err error) {
+func CheckDetachedSignature(keyring KeyRing, signed, signature io.Reader, config *packet.Config) (signer *Entity, err error) {
 	var issuerKeyId uint64
 	var hashFunc crypto.Hash
 	var sigType packet.SignatureType
@@ -416,10 +420,17 @@ func CheckDetachedSignature(keyring KeyRing, signed, signature io.Reader) (signe
 		switch sig := p.(type) {
 		case *packet.Signature:
 			err = key.PublicKey.VerifySignature(h, sig)
+			if err == nil && !sig.KeyExpired(config.Now()) {
+				err = errors.ErrSignatureExpired
+			}
 		case *packet.SignatureV3:
 			err = key.PublicKey.VerifySignatureV3(h, sig)
 		default:
 			panic("unreachable")
+		}
+
+		if err == errors.ErrSignatureExpired {
+			return key.Entity, err
 		}
 
 		if err == nil {
@@ -432,11 +443,11 @@ func CheckDetachedSignature(keyring KeyRing, signed, signature io.Reader) (signe
 
 // CheckArmoredDetachedSignature performs the same actions as
 // CheckDetachedSignature but expects the signature to be armored.
-func CheckArmoredDetachedSignature(keyring KeyRing, signed, signature io.Reader) (signer *Entity, err error) {
+func CheckArmoredDetachedSignature(keyring KeyRing, signed, signature io.Reader, config *packet.Config) (signer *Entity, err error) {
 	body, err := readArmored(signature, SignatureType)
 	if err != nil {
 		return
 	}
 
-	return CheckDetachedSignature(keyring, signed, body)
+	return CheckDetachedSignature(keyring, signed, body, config)
 }

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -359,7 +359,13 @@ type signatureWriter struct {
 func (s signatureWriter) Write(data []byte) (int, error) {
 	s.wrappedHash.Write(data)
 	flag := 0
-	return writeCanonical(s.literalData, data, &flag)
+	switch s.sigType {
+		case packet.SigTypeBinary:
+			return s.literalData.Write(data)
+		case packet.SigTypeText:
+			return writeCanonical(s.literalData, data, &flag)
+	}
+	return 0, errors.UnsupportedError("unsupported signature type: " + strconv.Itoa(int(s.sigType)))
 }
 
 func (s signatureWriter) Close() error {

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -173,6 +173,7 @@ func hashToHashId(h crypto.Hash) uint8 {
 func EncryptText(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHints, config *packet.Config) (plaintext io.WriteCloser, err error) {
 	return encrypt(ciphertext, to, signed, hints, packet.SigTypeText, config)
 }
+
 // Encrypt encrypts a message to a number of recipients and, optionally, signs
 // it. hints contains optional information, that is also encrypted, that aids
 // the recipients in processing the message. The resulting WriteCloser must
@@ -336,10 +337,11 @@ func encrypt(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHint
 		if err != nil {
 			return nil, err
 		}
-		return signatureWriter{encryptedData, literalData, hash, h, wrappedHash, signer, sigType, config}, nil
+		return signatureWriter{encryptedData, literalData, hash, wrappedHash, h, signer, sigType, config}, nil
 	}
 	return literalData, nil
 }
+
 // signatureWriter hashes the contents of a message while passing it along to
 // literalData. When closed, it closes literalData, writes a signature packet
 // to encryptedData and then also closes encryptedData.
@@ -347,16 +349,17 @@ type signatureWriter struct {
 	encryptedData io.WriteCloser
 	literalData   io.WriteCloser
 	hashType      crypto.Hash
-	wrappedHash	  hash.Hash
+	wrappedHash   hash.Hash
 	h             hash.Hash
 	signer        *packet.PrivateKey
-	sigType 	  packet.SignatureType
+	sigType       packet.SignatureType
 	config        *packet.Config
 }
 
 func (s signatureWriter) Write(data []byte) (int, error) {
 	s.wrappedHash.Write(data)
-	return s.literalData.Write(data)
+	flag := 0
+	return writeCanonical(s.literalData, data, &flag)
 }
 
 func (s signatureWriter) Close() error {


### PR DESCRIPTION
If you come up with something more elegant, I can rewrite... otherwise, just let's merge it.