### PR TITLE
Use latest-created valid self-signature

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -122,6 +122,7 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 			IssuerKeyId:  &e.PrimaryKey.KeyId,
 		},
 	}
+	e.Identities[uid.Id].Signatures = append(e.Identities[uid.Id].Signatures, e.Identities[uid.Id].SelfSignature)
 
 	// If the user passes in a DefaultHash via packet.Config,
 	// set the PreferredHash for the SelfSignature.


### PR DESCRIPTION
This PR uses the latest-created valid self-signature. The first self-signature is still required to be valid for simplicity, invalid subsequent self-signatures are still allowed and ignored, as before.

Self-signatures still aren't checked for expiry, nor creation time. That means that from this PR onwards, we may accidentally use self-signatures with a creation time in the future (i.e. that are not meant to be used yet). This should be an uncommon edge-case and would be slightly invasive to fix, but we should probably still do so in the future.