### PR TITLE
Fix openpgp s2k key parsing

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -7,6 +7,7 @@ package openpgp
 import (
 	"io"
 	"time"
+	goerrors "errors"
 
 	"golang.org/x/crypto/openpgp/armor"
 	"golang.org/x/crypto/openpgp/errors"
@@ -540,11 +541,13 @@ func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error
 }
 
 // SerializePrivate serializes an Entity, including private key material, to
-// the given Writer. For now, it must only be used on an Entity returned from
-// NewEntity.
+// the given Writer.
 // If config is nil, sensible defaults will be used.
-// TODO::notes this is a temp function to avoid break other things
 func (e *Entity) SerializePrivateNoSign(w io.Writer, config *packet.Config) (err error) {
+	if e.PrivateKey == nil {
+		return goerrors.New("openpgp: private key is missing")
+	}
+
 	err = e.PrivateKey.Serialize(w)
 	if err != nil {
 		return

--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -505,6 +505,10 @@ func shouldReplaceSubkeySig(existingSig, potentialNewSig *packet.Signature) bool
 // Identities and subkeys are re-signed in case they changed since NewEntry.
 // If config is nil, sensible defaults will be used.
 func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error) {
+	if e.PrivateKey == nil {
+		return goerrors.New("openpgp: private key is missing")
+	}
+
 	err = e.PrivateKey.Serialize(w)
 	if err != nil {
 		return

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -488,10 +488,50 @@ func TestNewEntityPublicSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 	serializedEntity := bytes.NewBuffer(nil)
-	entity.Serialize(serializedEntity)
+	err = entity.Serialize(serializedEntity)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = ReadEntity(packet.NewReader(bytes.NewBuffer(serializedEntity.Bytes())))
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNewEntityPrivateSerialization(t *testing.T) {
+	entity, err := NewEntity("Golang Gopher", "Test Key", "no-reply@golang.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedEntity := bytes.NewBuffer(nil)
+	err = entity.SerializePrivateNoSign(serializedEntity, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadEntity(packet.NewReader(bytes.NewBuffer(serializedEntity.Bytes())))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEntityPrivateSerialization(t *testing.T) {
+	keys, err := ReadArmoredKeyRing(bytes.NewBufferString(armoredPrivateKeyBlock))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, entity := range keys {
+		serializedEntity := bytes.NewBuffer(nil)
+		err = entity.SerializePrivateNoSign(serializedEntity, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := ReadEntity(packet.NewReader(bytes.NewBuffer(serializedEntity.Bytes())))
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -39,12 +39,12 @@ type PrivateKey struct {
 	sha1Checksum  bool
 	iv            []byte
 
-	// Full parameters of s2k packet
-	s2kParams s2k.Params
 	// Type of encryption of the S2K packet
 	// Allowed values are 0 (Not encrypted), 254 (SHA1), or
 	// 255 (2-byte checksum)
-	s2kType S2KType
+	s2kType       S2KType
+	// Full parameters of the S2K packet
+	s2kParams     *s2k.Params
 }
 
 //S2KType s2k packet type
@@ -380,13 +380,13 @@ func (pk *PrivateKey) Encrypt(passphrase []byte) error {
 
 	//Default config of private key encryption
 	pk.cipher = CipherAES256
-	s2kConfig := s2k.Config{
+	s2kConfig := &s2k.Config{
 		S2KMode:  3, //Iterated
 		S2KCount: 65536,
-		Hash:  crypto.SHA256,
+		Hash:     crypto.SHA256,
 	}
 
-	pk.s2kParams, err = s2kConfig.Generate(rand.Reader)
+	pk.s2kParams, err = s2k.Generate(rand.Reader, s2kConfig)
 	privateKeyBytes := privateKeyBuf.Bytes()
 	key := make([]byte, pk.cipher.KeySize())
 

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -147,7 +147,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		}
 		pk.cipher = CipherFunction(buf[0])
 		pk.Encrypted = true
-		pk.s2k, pk.s2kConfig, pk.salt, err = s2k.Parse(r)
+		pk.s2k, pk.s2kConfig, pk.salt, err = s2k.ParseWithConfig(r)
 		if err != nil {
 			return
 		}

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -44,7 +44,7 @@ func (ske *SymmetricKeyEncrypted) parse(r io.Reader) error {
 	}
 
 	var err error
-	ske.s2k, _, _, err = s2k.Parse(r)
+	ske.s2k, err = s2k.Parse(r)
 	if err != nil {
 		return err
 	}

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -44,7 +44,7 @@ func (ske *SymmetricKeyEncrypted) parse(r io.Reader) error {
 	}
 
 	var err error
-	ske.s2k, err = s2k.Parse(r)
+	ske.s2k, _, _, err = s2k.Parse(r)
 	if err != nil {
 		return err
 	}

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -282,10 +282,14 @@ func (params *Params) Serialize(encodedKeyBuf io.Writer) (err error) {
 	if _, err = encodedKeyBuf.Write([]byte{params.hashId}); err != nil {
 		return
 	}
-	if _, err = encodedKeyBuf.Write(params.salt); err != nil {
-		return
+	if params.mode > 0 {
+		if _, err = encodedKeyBuf.Write(params.salt); err != nil {
+			return
+		}
+		if params.mode == 3 {
+			_, err = encodedKeyBuf.Write([]byte{params.countByte})
+		}
 	}
-	_, err = encodedKeyBuf.Write([]byte{params.countByte})
 	return
 }
 

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -275,19 +275,19 @@ func (params *Params) Function() (f func(out, in []byte), err error) {
 	return nil, errors.UnsupportedError("S2K function")
 }
 
-func (params *Params) Serialize(encodedKeyBuf io.Writer) (err error) {
-	if _, err = encodedKeyBuf.Write([]byte{params.mode}); err != nil {
+func (params *Params) Serialize(w io.Writer) (err error) {
+	if _, err = w.Write([]byte{params.mode}); err != nil {
 		return
 	}
-	if _, err = encodedKeyBuf.Write([]byte{params.hashId}); err != nil {
+	if _, err = w.Write([]byte{params.hashId}); err != nil {
 		return
 	}
 	if params.mode > 0 {
-		if _, err = encodedKeyBuf.Write(params.salt); err != nil {
+		if _, err = w.Write(params.salt); err != nil {
 			return
 		}
 		if params.mode == 3 {
-			_, err = encodedKeyBuf.Write([]byte{params.countByte})
+			_, err = w.Write([]byte{params.countByte})
 		}
 	}
 	return

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -84,7 +84,7 @@ func TestParse(t *testing.T) {
 	for i, test := range parseTests {
 		spec, _ := hex.DecodeString(test.spec)
 		buf := bytes.NewBuffer(spec)
-		f, s2kconfig, salt, err := Parse(buf)
+		f, s2kconfig, salt, err := ParseWithConfig(buf)
 		if err != nil {
 			t.Errorf("%d: Parse returned error: %s", i, err)
 			continue
@@ -134,7 +134,7 @@ func testSerializeConfig(t *testing.T, c *Config) {
 		return
 	}
 
-	f, _, _, err := Parse(buf)
+	f, err := Parse(buf)
 	if err != nil {
 		t.Errorf("failed to reparse: %s", err)
 		return

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -74,13 +74,13 @@ var parseTests = []struct {
 }{
 	/* Simple with SHA1 */
 	{"0002", "hello", "aaf4c61d",
-		Params{0, crypto.SHA1, 0, nil}},
+		Params{0, 0x02, 0, nil}},
 	/* Salted with SHA1 */
 	{"01020102030405060708", "hello", "f4f7d67e",
-		Params{1, crypto.SHA1, 0, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
+		Params{1, 0x02, 0, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
 	/* Iterated with SHA1 */
 	{"03020102030405060708f1", "hello", "f2a57b7c",
-		Params{3, crypto.SHA1, 35651584, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
+		Params{3, 0x02, 0xf1, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
 }
 
 func TestParseIntoParams(t *testing.T) {
@@ -93,7 +93,7 @@ func TestParseIntoParams(t *testing.T) {
 			continue
 		}
 
-		if test.params.mode != params.mode || test.params.hash != params.hash || test.params.count != params.count ||
+		if test.params.mode != params.mode || test.params.hashID != params.hashID || test.params.countByte != params.countByte ||
 			!bytes.Equal(test.params.salt, params.salt) {
 			t.Errorf("%d: Wrong s2kconfig, got: %+v want: %+v", i, params, test.params)
 		}

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -74,13 +74,13 @@ var parseTests = []struct {
 }{
 	/* Simple with SHA1 */
 	{"0002", "hello", "aaf4c61d",
-		Params{0, 0x02, 0, nil}},
+		Params{0, 0x02, nil, 0}},
 	/* Salted with SHA1 */
 	{"01020102030405060708", "hello", "f4f7d67e",
-		Params{1, 0x02, 0, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
+		Params{1, 0x02, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }, 0}},
 	/* Iterated with SHA1 */
 	{"03020102030405060708f1", "hello", "f2a57b7c",
-		Params{3, 0x02, 0xf1, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }}},
+		Params{3, 0x02, []byte{ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }, 0xf1}},
 }
 
 func TestParseIntoParams(t *testing.T) {
@@ -93,7 +93,7 @@ func TestParseIntoParams(t *testing.T) {
 			continue
 		}
 
-		if test.params.mode != params.mode || test.params.hashID != params.hashID || test.params.countByte != params.countByte ||
+		if test.params.mode != params.mode || test.params.hashId != params.hashId || test.params.countByte != params.countByte ||
 			!bytes.Equal(test.params.salt, params.salt) {
 			t.Errorf("%d: Wrong s2kconfig, got: %+v want: %+v", i, params, test.params)
 		}

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -110,6 +110,15 @@ func TestParseIntoParams(t *testing.T) {
 		if !bytes.Equal(out, expectedHash) {
 			t.Errorf("%d: Wrong output got: %x want: %x", i, out, expectedHash)
 		}
+		var reserialized bytes.Buffer
+		err = params.Serialize(&reserialized)
+		if err != nil {
+			t.Errorf("%d: params.Serialize() returned error: %s", i, err)
+			continue
+		}
+		if !bytes.Equal(reserialized.Bytes(), spec) {
+			t.Errorf("%d: Wrong reserialized got: %x want: %x", i, reserialized.Bytes(), spec)
+		}
 		if testing.Short() {
 			break
 		}


### PR DESCRIPTION
Fix key parsing, save s2k specifications in the `privatekey` object when parsing to then be able to serialise the key without decrypting and re-encrypting