### PR TITLE
Refactor NewEntity, force preferred lists at key generation

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -6,6 +6,7 @@ package openpgp
 
 import (
 	"math/big"
+	"time"
 
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/openpgp/ecdh"
@@ -14,8 +15,6 @@ import (
 	"golang.org/x/crypto/openpgp/packet"
 	"golang.org/x/crypto/rsa"
 )
-
-const defaultRSAKeyBits = 2048
 
 // NewEntity returns an Entity that contains a fresh RSA/RSA keypair with a
 // single identity composed of the given full name, comment and email, any of
@@ -29,150 +28,128 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 		return nil, errors.InvalidArgumentError("user id field contained invalid characters")
 	}
 
-	var pubPrimary *packet.PublicKey
-	var privPrimary *packet.PrivateKey
+	// Generate a primary key with one subkey
+	var primary, sub *packet.PrivateKey
+	var err error
 
-	var pubSubkey *packet.PublicKey
-	var privSubkey *packet.PrivateKey
-
-	primarykeyAlgorithm := packet.PubKeyAlgoRSA
-	if config != nil && uint8(config.Algorithm) != 0 {
-		primarykeyAlgorithm = config.Algorithm
-	}
-	var subkeyAlgorithm packet.PublicKeyAlgorithm
-
-	if primarykeyAlgorithm == packet.PubKeyAlgoRSA {
-
-		bits := defaultRSAKeyBits
-		if config != nil && config.RSABits != 0 {
-			bits = config.RSABits
-		}
-
-		var primaryPrimes []*big.Int
-		if config != nil && len(config.RSAPrimes) >= 2 {
-			primaryPrimes = config.RSAPrimes[0:2]
-		}
-
-		primaryKey, err := rsa.GenerateKeyWithPrimes(config.Random(), bits, primaryPrimes)
-		if err != nil {
-			return nil, err
-		}
-
-		privPrimary = packet.NewRSAPrivateKey(creationTime, primaryKey)
-		pubPrimary = packet.NewRSAPublicKey(creationTime, &primaryKey.PublicKey)
-
-		var subkeyPrimes []*big.Int
-		if config != nil && len(config.RSAPrimes) >= 4 {
-			subkeyPrimes = config.RSAPrimes[2:4]
-		}
-
-		subkey, err := rsa.GenerateKeyWithPrimes(config.Random(), bits, subkeyPrimes)
-		if err != nil {
-			return nil, err
-		}
-
-		pubSubkey = packet.NewRSAPublicKey(creationTime, &subkey.PublicKey)
-		privSubkey = packet.NewRSAPrivateKey(creationTime, subkey)
-
-		subkeyAlgorithm = packet.PubKeyAlgoRSA
-
-	} else if primarykeyAlgorithm == packet.PubKeyAlgoEdDSA {
-
-		pubPrimaryKey, primaryKey, err := ed25519.GenerateKey(config.Random())
-		if err != nil {
-			return nil, err
-		}
-
-		privPrimary = packet.NewEdDSAPrivateKey(creationTime, primaryKey)
-		pubPrimary = packet.NewEdDSAPublicKey(creationTime, pubPrimaryKey)
-
-		var kdf = ecdh.KDF{
-			Hash:   algorithm.SHA512,
-			Cipher: algorithm.AES256,
-		}
-
-		privSubkeyRaw, err := ecdh.X25519GenerateKey(config.Random(), kdf)
-		if err != nil {
-			return nil, err
-		}
-
-		pubSubkey = packet.NewECDHPublicKey(creationTime, &privSubkeyRaw.PublicKey)
-		privSubkey = packet.NewECDHPrivateKey(creationTime, privSubkeyRaw)
-
-		subkeyAlgorithm = packet.PubKeyAlgoEdDSA
-
-	} else {
+	switch config.PublicKeyAlgorithm() {
+	case packet.PubKeyAlgoRSA:
+		primary, sub, err = rsaGen(config, creationTime)
+	case packet.PubKeyAlgoEdDSA:
+		primary, sub, err = eddsaGen(config, creationTime)
+	default:
 		return nil, errors.InvalidArgumentError("unsupported public key algorithm")
 	}
-
-	e := &Entity{
-		PrimaryKey: pubPrimary,
-		PrivateKey: privPrimary,
-		Identities: make(map[string]*Identity),
-	}
-	isPrimaryId := true
-	e.Identities[uid.Id] = &Identity{
-		Name:   uid.Id,
-		UserId: uid,
-		SelfSignature: &packet.Signature{
-			CreationTime: creationTime,
-			SigType:      packet.SigTypePositiveCert,
-			PubKeyAlgo:   primarykeyAlgorithm,
-			Hash:         config.Hash(),
-			IsPrimaryId:  &isPrimaryId,
-			FlagsValid:   true,
-			FlagSign:     true,
-			FlagCertify:  true,
-			// Set MDC true by default, see 5.8 vs. 5.14
-			MDC:          true,
-			AEAD:         config.AEAD() != nil,
-			IssuerKeyId:  &e.PrimaryKey.KeyId,
-		},
-	}
-	e.Identities[uid.Id].Signatures = append(e.Identities[uid.Id].Signatures, e.Identities[uid.Id].SelfSignature)
-
-	// If the user passes in a DefaultHash via packet.Config,
-	// set the PreferredHash for the SelfSignature.
-	if config != nil && config.DefaultHash != 0 {
-		e.Identities[uid.Id].SelfSignature.PreferredHash = []uint8{hashToHashId(config.DefaultHash)}
-	}
-
-	// Likewise for DefaultCipher.
-	if config != nil && config.DefaultCipher != 0 {
-		e.Identities[uid.Id].SelfSignature.PreferredSymmetric = []uint8{uint8(config.DefaultCipher)}
-	}
-
-	// And for DefaultMode.
-	if config.AEAD() != nil && config.AEAD().DefaultMode != 0 {
-		e.Identities[uid.Id].SelfSignature.PreferredAEAD = []uint8{uint8(config.AEAD().DefaultMode)}
-	}
-
-	err := e.Identities[uid.Id].SelfSignature.SignUserId(uid.Id, e.PrimaryKey, e.PrivateKey, config)
 	if err != nil {
 		return nil, err
 	}
 
-	e.Subkeys = make([]Subkey, 1)
-	e.Subkeys[0] = Subkey{
-		PublicKey:  pubSubkey,
-		PrivateKey: privSubkey,
+	subKey := Subkey{
+		PrivateKey: sub,
+		PublicKey:  &sub.PublicKey,
 		Sig: &packet.Signature{
 			CreationTime:              creationTime,
 			SigType:                   packet.SigTypeSubkeyBinding,
-			PubKeyAlgo:                subkeyAlgorithm,
+			PubKeyAlgo:                config.PublicKeyAlgorithm(),
 			Hash:                      config.Hash(),
 			FlagsValid:                true,
 			FlagEncryptStorage:        true,
 			FlagEncryptCommunications: true,
-			IssuerKeyId:               &e.PrimaryKey.KeyId,
+			IssuerKeyId:               &primary.PublicKey.KeyId,
 		},
 	}
-	e.Subkeys[0].PublicKey.IsSubkey = true
-	e.Subkeys[0].PrivateKey.IsSubkey = true
-	err = e.Subkeys[0].Sig.SignKey(e.Subkeys[0].PublicKey, e.PrivateKey, config)
+
+	// Binding signatures
+	err = subKey.Sig.SignKey(subKey.PublicKey, primary, config)
+	if err != nil {
+		return nil, err
+	}
+	isPrimaryId := true
+	selfSignature := &packet.Signature{
+		SigType:            packet.SigTypePositiveCert,
+		PubKeyAlgo:         config.PublicKeyAlgorithm(),
+		Hash:               config.Hash(),
+		CreationTime:       creationTime,
+		PreferredSymmetric: config.PreferredSymmetricAlgorithms(),
+		PreferredHash:      config.PreferredHashAlgorithms(),
+		PreferredAEAD:      config.AEAD().PreferredAEADModes(),
+		IssuerKeyId:        &primary.PublicKey.KeyId,
+		IsPrimaryId:        &isPrimaryId,
+		FlagsValid:         true,
+		FlagSign:           true,
+		FlagCertify:        true,
+		MDC:                true, // true by default, see 5.8 vs. 5.14
+		AEAD:               config.AEAD() != nil,
+	}
+	err = selfSignature.SignUserId(uid.Id, &primary.PublicKey, primary, config)
 	if err != nil {
 		return nil, err
 	}
 
-	return e, nil
+	return &Entity{
+		PrivateKey: primary,
+		PrimaryKey: &primary.PublicKey,
+		Subkeys: []Subkey{subKey},
+		Identities: map[string]*Identity{
+			uid.Id: &Identity{
+				Name:          uid.Id,
+				UserId:        uid,
+				SelfSignature: selfSignature,
+				Signatures:    []*packet.Signature{selfSignature},
+			},
+		},
+	}, nil
+}
+
+// Generates a primary key and a subkey with RSA and the given config.
+func rsaGen(config *packet.Config, creationTime time.Time) (primary *packet.PrivateKey, sub *packet.PrivateKey, err error) {
+	bits := config.RSAModulusBits()
+	var primaryPrimes []*big.Int
+	if config != nil && len(config.RSAPrimes) >= 2 {
+		primaryPrimes = config.RSAPrimes[0:2]
+	}
+	primaryPrivRaw, err := rsa.GenerateKeyWithPrimes(config.Random(), bits, primaryPrimes)
+	if err != nil {
+		return nil, nil, err
+	}
+	primary = packet.NewRSAPrivateKey(creationTime, primaryPrivRaw)
+	primary.PublicKey = *packet.NewRSAPublicKey(creationTime, &primaryPrivRaw.PublicKey)
+
+	var subkeyPrimes []*big.Int
+	if config != nil && len(config.RSAPrimes) >= 4 {
+		subkeyPrimes = config.RSAPrimes[2:4]
+	}
+	subPrivRaw, err := rsa.GenerateKeyWithPrimes(config.Random(), bits, subkeyPrimes)
+	if err != nil {
+		return nil, nil, err
+	}
+	sub = packet.NewRSAPrivateKey(creationTime, subPrivRaw)
+	sub.PublicKey = *packet.NewRSAPublicKey(creationTime, &subPrivRaw.PublicKey)
+	sub.IsSubkey = true
+	sub.PublicKey.IsSubkey = true
+	return
+}
+
+// Generates a primary key and a subkey with EdDSA and the given config.
+func eddsaGen(config *packet.Config, creationTime time.Time) (primary *packet.PrivateKey, sub *packet.PrivateKey, err error) {
+	primaryPubRaw, primaryPrivRaw, err := ed25519.GenerateKey(config.Random())
+	if err != nil {
+		return nil, nil, err
+	}
+	primary = packet.NewEdDSAPrivateKey(creationTime, primaryPrivRaw)
+	primary.PublicKey = *packet.NewEdDSAPublicKey(creationTime, primaryPubRaw)
+
+	var kdf = ecdh.KDF{
+		Hash:   algorithm.SHA512,
+		Cipher: algorithm.AES256,
+	}
+	subPrivRaw, err := ecdh.X25519GenerateKey(config.Random(), kdf)
+	if err != nil {
+		return nil, nil, err
+	}
+	sub = packet.NewECDHPrivateKey(creationTime, subPrivRaw)
+	sub.PublicKey = *packet.NewECDHPublicKey(creationTime, &subPrivRaw.PublicKey)
+	sub.IsSubkey = true
+	sub.PublicKey.IsSubkey = true
+	return
 }

--- a/openpgp/packet/aead_config.go
+++ b/openpgp/packet/aead_config.go
@@ -26,6 +26,17 @@ func (conf *AEADConfig) Mode() AEADMode {
 	return mode
 }
 
+func (conf *AEADConfig) PreferredAEADModes() []uint8 {
+	if conf == nil {
+		return []uint8{}
+	}
+	switch conf.DefaultMode {
+	case AEADModeEAX, AEADModeOCB:
+		return []uint8{uint8(conf.DefaultMode)}
+	}
+	return []uint8{}
+}
+
 // ChunkSizeByte returns the byte indicating the chunk size. The effective
 // chunk size is computed with the formula uint64(1) << (chunkSizeByte + 6)
 func (conf *AEADConfig) ChunkSizeByte() byte {

--- a/openpgp/packet/aead_config.go
+++ b/openpgp/packet/aead_config.go
@@ -26,17 +26,6 @@ func (conf *AEADConfig) Mode() AEADMode {
 	return mode
 }
 
-func (conf *AEADConfig) PreferredAEADModes() []uint8 {
-	if conf == nil {
-		return []uint8{}
-	}
-	switch conf.DefaultMode {
-	case AEADModeEAX, AEADModeOCB:
-		return []uint8{uint8(conf.DefaultMode)}
-	}
-	return []uint8{}
-}
-
 // ChunkSizeByte returns the byte indicating the chunk size. The effective
 // chunk size is computed with the formula uint64(1) << (chunkSizeByte + 6)
 func (conf *AEADConfig) ChunkSizeByte() byte {

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -10,9 +10,6 @@ import (
 	"io"
 	"math/big"
 	"time"
-
-	"golang.org/x/crypto/openpgp/internal/algorithm"
-	"golang.org/x/crypto/openpgp/s2k"
 )
 
 // Config collects a number of parameters along with sensible defaults.
@@ -76,24 +73,7 @@ func (c *Config) Hash() crypto.Hash {
 	if c == nil || uint(c.DefaultHash) == 0 {
 		return crypto.SHA256
 	}
-	_, ok := s2k.HashToHashId(c.DefaultHash)
-	if ok {
-		return c.DefaultHash
-	}
-	return crypto.SHA256
-}
-
-func (c *Config) PreferredHashAlgorithms() []uint8 {
-	mustId, _ := s2k.HashToHashId(crypto.SHA256)
-	if c == nil {
-		return []uint8{mustId}
-	}
-	switch c.DefaultHash {
-	case crypto.SHA224, crypto.SHA384, crypto.SHA512, crypto.SHA1, crypto.MD5, crypto.RIPEMD160:
-		id, _ := s2k.HashToHashId(c.DefaultHash)
-		return []uint8{id, mustId}
-	}
-	return []uint8{mustId}
+	return c.DefaultHash
 }
 
 func (c *Config) Cipher() CipherFunction {
@@ -101,18 +81,6 @@ func (c *Config) Cipher() CipherFunction {
 		return CipherAES128
 	}
 	return c.DefaultCipher
-}
-
-func (c *Config) PreferredSymmetricAlgorithms() []uint8 {
-	mustId:= algorithm.AES128.Id()
-	if c == nil {
-		return []uint8{mustId}
-	}
-	switch c.DefaultCipher {
-	case CipherAES192, CipherAES256, CipherCAST5, Cipher3DES:
-		return []uint8{uint8(c.DefaultCipher), mustId}
-	}
-	return []uint8{mustId}
 }
 
 func (c *Config) Now() time.Time {

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -376,14 +376,14 @@ func TestEncryptDecryptEdDSAPrivateKeyRandomizeFast(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	privKey := *NewEdDSAPrivateKey(time.Now(), primaryKey)
+	privKey := *NewEdDSAPrivateKey(time.Now(), &primaryKey)
 	copiedPrivKey := make([]byte, len(primaryKey))
-	copy(copiedPrivKey, privKey.PrivateKey.(ed25519.PrivateKey))
+	copy(copiedPrivKey, *privKey.PrivateKey.(*ed25519.PrivateKey))
 	// Encrypt private key with random passphrase
 	privKey.Encrypt(password)
 	// Decrypt and check correctness
 	privKey.Decrypt(password)
-	if !bytes.Equal(privKey.PrivateKey.(ed25519.PrivateKey), copiedPrivKey) {
+	if !bytes.Equal(*privKey.PrivateKey.(*ed25519.PrivateKey), copiedPrivKey) {
 		t.Fatalf("Private key was not correctly decrypted:\ngot:\n%v\nwant:\n%v", privKey.PrivateKey, copiedPrivKey)
 	}
 }

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -128,12 +128,8 @@ ParsePackets:
 			for _, k := range keys {
 				pubKeys = append(pubKeys, keyEnvelopePair{k, p})
 			}
-		case *packet.SymmetricallyEncrypted:
-			edp = p
-			break ParsePackets
-		case *packet.AEADEncrypted:
-			// edp = p.(*EncryptedDataPacket)
-			edp = p
+		case *packet.SymmetricallyEncrypted, *packet.AEADEncrypted:
+			edp = p.(packet.EncryptedDataPacket)
 			break ParsePackets
 		case *packet.Compressed, *packet.LiteralData, *packet.OnePassSignature:
 			// This message isn't encrypted.

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -83,6 +83,7 @@ func TestNewEntity(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to find bit length: %s", err)
 	}
+	defaultRSAKeyBits := 2048
 	if int(bl) != defaultRSAKeyBits {
 		t.Errorf("BitLength %v, expected %v", int(bl), defaultRSAKeyBits)
 	}


### PR DESCRIPTION
Currently, packet configurations only accept single defaults for Hash, Cipher, and AEAD mode. Upon key generation, NewEntity hardcodes a one-list element with the explicit default given; moreover, if a nil config is given, then the resulting preferences are empty, see e.g.TestNewEntityNilConfigPreferred*.

This PR proposes to change this behavior. A list of preferences shall always be encoded into packets upon key generation. If `Default{Hash, Cipher}` is used, then the list consists of the given algorithm, plus the MUST-implement algorithm (SHA256 and AES128, respectively). If instead `config == nil`, the list consists in the MUST-implement algorithm only.

NewEntity has been refactored for legibility, and tests have been added/adapted accordingly.