### PR TITLE
Fix unencrypted private key serialization

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -258,6 +258,11 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	if err != nil {
 		return
 	}
+
+	if !pk.Encrypted && !pk.Dummy() {
+		pk.s2kType = S2KNON
+	}
+
 	if _, err = contents.Write([]byte{uint8(pk.s2kType)}); err != nil {
 		return
 	}
@@ -286,10 +291,10 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 			if err != nil {
 				return err
 			}
-			l = buf.Len()
+			priv, l = buf.Bytes(), buf.Len()
 			if pk.sha1Checksum {
 				h := sha1.New()
-				io.Copy(h, buf)
+				h.Write(priv)
 				buf.Write(h.Sum(nil))
 			} else {
 				checksum := mod64kHash(buf.Bytes())

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -291,10 +291,10 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 			if err != nil {
 				return err
 			}
-			priv, l = buf.Bytes(), buf.Len()
+			l = buf.Len()
 			if pk.sha1Checksum {
 				h := sha1.New()
-				h.Write(priv)
+				h.Write(buf.Bytes())
 				buf.Write(h.Sum(nil))
 			} else {
 				checksum := mod64kHash(buf.Bytes())


### PR DESCRIPTION
Only the hash was being serialized, instead of the actual private data.