### PR TITLE
Remove an unnecessary range check when generating x25519 private keys

### DIFF
--- a/openpgp/ecdh/x25519.go
+++ b/openpgp/ecdh/x25519.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Generates a private-public key-pair.
-// 'priv' is a private key; a scalar belonging to the set
+// 'priv' is a private key; a little-endian scalar belonging to the set
 // 2^{254} + 8 * [0, 2^{251}), in order to avoid the small subgroup of the
 // curve. 'pub' is simply 'priv' * G where G is the base point.
 // See https://cr.yp.to/ecdh.html and RFC7748, sec 5.
@@ -26,9 +26,14 @@ func x25519GenerateKeyPairBytes(rand io.Reader) (priv [32]byte, pub [32]byte, er
 	if err != nil {
 		return
 	}
+
 	// The following ensures that the private key is a number of the form
 	// 2^{254} + 8 * [0, 2^{251}), in order to avoid the small subgroup of
 	// of the curve.
+	//
+	// This masking is done internally to ScalarBaseMult and so is unnecessary
+	// for security, but OpenPGP implementations require that private keys be
+	// pre-masked.
 	priv[0] &= 248
 	priv[31] &= 127
 	priv[31] |= 64


### PR DESCRIPTION
This was attempting to limit private keys to be below the prime order subgroup size, which isn't needed. Moreover, it was incorrecly implemented, interpreting the bytes as big-endian instead of little-endian. This removal should also improve performance, as the previous generation loop would run an expected 16 times.