### PR TITLE
feat: add new constructor for an ecdsa.PublicKey

### DIFF
--- a/openpgp/ecdsa/ecdsa.go
+++ b/openpgp/ecdsa/ecdsa.go
@@ -3,10 +3,12 @@
 package ecdsa
 
 import (
+	"crypto/elliptic"
 	"errors"
-	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
 	"io"
 	"math/big"
+
+	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
 )
 
 type PublicKey struct {
@@ -17,6 +19,14 @@ type PublicKey struct {
 type PrivateKey struct {
 	PublicKey
 	D *big.Int
+}
+
+// NewPublicKeyFromCurve takes an elliptic curve, and returns a PublicKey
+// of that curve type.
+func NewPublicKeyFromCurve(c elliptic.Curve) *PublicKey {
+	return &PublicKey{
+		curve: ecc.NewGenericCurve(c),
+	}
 }
 
 func NewPublicKey(curve ecc.ECDSACurve) *PublicKey {


### PR DESCRIPTION
The existing NewPublicKey was unusable from an external package due to the fact that it used an internal package interface in its function signature.

The new constructor uses the elliptic.Curve interface from the standard library instead.