### PR TITLE
openpgp/packet: fix dropped test errors

### DIFF
--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -80,6 +80,9 @@ func TestAeadEmptyStream(t *testing.T) {
 	}
 	// decrypted plaintext can be read from 'rc'
 	rc, err := packet.decrypt(key)
+	if err != nil {
+		t.Errorf("Error decrypting packet: %s", err)
+	}
 
 	_, err = readDecryptedStream(rc)
 	if err != nil {
@@ -97,6 +100,9 @@ func TestAeadEmptyStream(t *testing.T) {
 	}
 	// decrypted plaintext can be read from 'rc'
 	rc, err = packet.decrypt(key)
+	if err != nil {
+		t.Errorf("Error decrypting packet: %s", err)
+	}
 
 	_, err = readDecryptedStream(rc)
 	if err == nil {
@@ -127,6 +133,9 @@ func TestAeadNilConfigStream(t *testing.T) {
 	}
 	// decrypted plaintext can be read from 'rc'
 	rc, err := packet.decrypt(key)
+	if err != nil {
+		t.Errorf("Error decrypting packet: %s", err)
+	}
 
 	got, err := readDecryptedStream(rc)
 	if err != nil {
@@ -161,6 +170,9 @@ func TestAeadStreamRandomizeSlow(t *testing.T) {
 	}
 	// decrypted plaintext can be read from 'rc'
 	rc, err := packet.decrypt(key)
+	if err != nil {
+		t.Errorf("Error decrypting packet: %s", err)
+	}
 
 	got, err := readDecryptedStream(rc)
 	if err != nil {
@@ -206,6 +218,9 @@ func TestAeadCorruptStreamRandomizeSlow(t *testing.T) {
 		return
 	}
 	rc, err := packet.decrypt(key)
+	if err != nil {
+		t.Errorf("Error decrypting packet: %s", err)
+	}
 	got, err := readDecryptedStream(rc)
 	if err == nil || err == io.EOF {
 		t.Errorf("No error raised when decrypting corrupt stream")

--- a/openpgp/packet/compressed_test.go
+++ b/openpgp/packet/compressed_test.go
@@ -68,6 +68,9 @@ func TestCompressDecompressRandomizeFast(t *testing.T) {
 	wcomp.Close()
 	// Read the packet and decompress
 	p, err := Read(w)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c, ok := p.(*Compressed)
 	if !ok {
 		t.Error("didn't find Compressed packet")

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -102,6 +102,9 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 							}
 
 							key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
+							if err != nil {
+								t.Errorf("failed to serialize encrypted symmetric key: %s", err)
+							}
 							p, err := Read(&buf)
 							if err != nil {
 								t.Errorf("failed to reparse %s", err)
@@ -151,7 +154,7 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 					config := &Config{
 						DefaultCipher: cipher,
 						S2KConfig: &s2k.Config{
-							S2KMode: s2ktype,
+							S2KMode:                 s2ktype,
 							PassphraseIsHighEntropy: true,
 						},
 					}


### PR DESCRIPTION
This picks up several dropped `err` variables in the `openpgp/packet` tests.

None of these appear to have been silently failing, and the tests should still pass.