### PR TITLE
v1 API: Only allow acceptable hashes when writing signatures

### DIFF
--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -880,7 +880,7 @@ func (s signatureWriter) Close() error {
 	return s.encryptedData.Close()
 }
 
-func adaptHashToSigningKey(config *packet.Config, primary *packet.PublicKey) crypto.Hash {
+func selectHashForSigningKey(config *packet.Config, primary *packet.PublicKey) crypto.Hash {
 	acceptableHashes := acceptableHashesToWrite(primary)
 	hash, ok := algorithm.HashToHashId(config.Hash())
 	if !ok {
@@ -893,17 +893,16 @@ func adaptHashToSigningKey(config *packet.Config, primary *packet.PublicKey) cry
 	}
 	if len(acceptableHashes) > 0 {
 		defaultAcceptedHash, ok := algorithm.HashIdToHash(acceptableHashes[0])
-		if !ok {
-			return config.Hash()
+		if ok {
+			return defaultAcceptedHash
 		}
-		return defaultAcceptedHash
 	}
 	return config.Hash()
 }
 
 func createSignaturePacket(signer *packet.PublicKey, sigType packet.SignatureType, config *packet.Config) *packet.Signature {
 	sigLifetimeSecs := config.SigLifetime()
-	hash := adaptHashToSigningKey(config, signer)
+	hash := selectHashForSigningKey(config, signer)
 	return &packet.Signature{
 		Version:           signer.Version,
 		SigType:           sigType,


### PR DESCRIPTION
RFC 9580 mandates the use of specific hash algorithms for certain signature algorithms. While the v2 API already enforces these restrictions, this PR ports the same logic to the v1 API to ensure that invalid or non-compliant data cannot be written.