### PR TITLE
parse trust packet

### DIFF
--- a/openpgp/packet/opaque_test.go
+++ b/openpgp/packet/opaque_test.go
@@ -48,7 +48,7 @@ func TestOpaqueParseReason(t *testing.T) {
 		count++
 	}
 
-	const expectedBad = 3
+	const expectedBad = 2
 	// Test post-conditions, make sure we actually parsed packets as expected.
 	if badPackets != expectedBad {
 		t.Errorf("unexpected # unparseable packets: %d (want %d)", badPackets, expectedBad)

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -375,8 +375,7 @@ func Read(r io.Reader) (p Packet, err error) {
 	case packetTypeMarker:
 		p = new(Marker)
 	case packetTypeTrust:
-		// Not implemented, just consume
-		err = errors.UnknownPacketTypeError(tag)
+		p = new(Trust)
 	default:
 		// Packet Tags from 0 to 39 are critical.
 		// Packet Tags from 40 to 63 are non-critical.
@@ -439,8 +438,7 @@ func ReadWithCheck(r io.Reader, sequence *SequenceVerifier) (p Packet, msgErr er
 	case packetTypeMarker:
 		p = new(Marker)
 	case packetTypeTrust:
-		// Not implemented, just consume
-		err = errors.UnknownPacketTypeError(tag)
+		p = new(Trust)
 	case packetTypePrivateKey,
 		packetTypePrivateSubkey,
 		packetTypePublicKey,

--- a/openpgp/packet/trust.go
+++ b/openpgp/packet/trust.go
@@ -1,0 +1,26 @@
+package packet
+
+import (
+	"io"
+)
+
+type Trust struct {
+	Contents []byte
+}
+
+// parse performs no checks, just imports the raw packet body contents.
+// It is the application's responsibility to check the contents.
+func (t *Trust) parse(reader io.Reader) (err error) {
+	t.Contents, err = io.ReadAll(reader)
+	return
+}
+
+// Serialize marshals the trust packet to writer in the form of an OpenPGP packet, including header.
+func (t *Trust) Serialize(writer io.Writer) error {
+	err := serializeHeader(writer, packetTypeTrust, len(t.Contents))
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(t.Contents)
+	return err
+}


### PR DESCRIPTION
A minimal change to expose a trust packet as a []byte slice to the application layer. It is the application's responsibility to handle the packet contents.