### PR TITLE
Ensure generated RSA key primes satisfy P < Q constraint

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -279,7 +279,7 @@ func newSigner(config *packet.Config) (signer interface{}, err error) {
 			config.RSAPrimes = config.RSAPrimes[2:]
 			return generateRSAKeyWithPrimes(config.Random(), 2, bits, primes)
 		}
-		return rsa.GenerateKey(config.Random(), bits)
+		return generateRSAKey(config.Random(), bits)
 	case packet.PubKeyAlgoEdDSA:
 		if config.V6() {
 			// Implementations MUST NOT accept or generate v6 key material
@@ -337,7 +337,7 @@ func newDecrypter(config *packet.Config) (decrypter interface{}, err error) {
 			config.RSAPrimes = config.RSAPrimes[2:]
 			return generateRSAKeyWithPrimes(config.Random(), 2, bits, primes)
 		}
-		return rsa.GenerateKey(config.Random(), bits)
+		return generateRSAKey(config.Random(), bits)
 	case packet.PubKeyAlgoEdDSA, packet.PubKeyAlgoECDSA:
 		fallthrough // When passing EdDSA or ECDSA, we generate an ECDH subkey
 	case packet.PubKeyAlgoECDH:
@@ -367,6 +367,22 @@ func newDecrypter(config *packet.Config) (decrypter interface{}, err error) {
 }
 
 var bigOne = big.NewInt(1)
+
+// generateRSAKey generates an RSA keypair and ensures that p < q as required by RFC 9580.
+func generateRSAKey(random io.Reader, bits int) (*rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(random, bits)
+	if err != nil {
+		return nil, err
+	}
+	// RFC 9580 section 5.5.5.1 requires p < q for RSA keys.
+	// The Go standard library does not guarantee this, so we swap if needed
+	// and recompute the precomputed values.
+	if len(key.Primes) == 2 && key.Primes[0].Cmp(key.Primes[1]) > 0 {
+		key.Primes[0], key.Primes[1] = key.Primes[1], key.Primes[0]
+		key.Precompute()
+	}
+	return key, nil
+}
 
 // generateRSAKeyWithPrimes generates a multi-prime RSA keypair of the
 // given bit size, using the given random source and pre-populated primes.
@@ -449,6 +465,11 @@ NextSetOfPrimes:
 			priv.N = n
 			break
 		}
+	}
+
+	// RFC 9580 section 5.5.5.1 requires p < q for RSA keys.
+	if len(priv.Primes) == 2 && priv.Primes[0].Cmp(priv.Primes[1]) > 0 {
+		priv.Primes[0], priv.Primes[1] = priv.Primes[1], priv.Primes[0]
 	}
 
 	priv.Precompute()

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -1867,37 +1867,6 @@ mQ00BF00000BCAD0000000000000000000000000000000000000000000000000
 	ReadArmoredKeyRing(strings.NewReader(data))
 }
 
-type DeterministicReader struct {
-	data []byte
-	// tracks the current read position in the data buffer
-	offset int
-}
-
-func (r *DeterministicReader) Read(p []byte) (n int, err error) {
-	if r.offset >= len(r.data) {
-		return 0, io.EOF
-	}
-
-	if len(p) == 0 {
-		return 0, nil
-	}
-
-	remaining := len(r.data) - r.offset
-	n = len(p)
-	if n > remaining {
-		n = remaining
-	}
-
-	copy(p, r.data[r.offset:r.offset+n])
-	r.offset += n
-
-	if r.offset >= len(r.data) {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
 func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 	// Hard-coded primes for a 2048-bit RSA key were taken from https://github.com/jam-awake/gpg-verify-bug
 	// using key with fingerprint: 2A25F94C4E482847305AB91E46EF00DD763B1D37
@@ -1918,14 +1887,11 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 	bits := 2048
 	primeSize := bits / 8
 
-	createReader := func() *DeterministicReader {
+	createReader := func() *bytes.Reader {
 		readerBuffer := make([]byte, primeSize*2)
 		p.FillBytes(readerBuffer[primeSize:])
 		q.FillBytes(readerBuffer[:primeSize])
-		return &DeterministicReader{
-			data:   readerBuffer,
-			offset: 0,
-		}
+		return bytes.NewReader(readerBuffer)
 	}
 
 	verifyRSAKey := func(t *testing.T, key *rsa.PrivateKey, err error) {
@@ -1966,18 +1932,18 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		generateKey func(reader *DeterministicReader) (*rsa.PrivateKey, error)
+		generateKey func(reader *bytes.Reader) (*rsa.PrivateKey, error)
 	}{
 		{
 			name: "generateRSAKeyWithPrimes",
-			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+			generateKey: func(reader *bytes.Reader) (*rsa.PrivateKey, error) {
 				noPrepopulatedPrimes := []*big.Int{}
 				return generateRSAKeyWithPrimes(reader, 2, bits, noPrepopulatedPrimes)
 			},
 		},
 		{
 			name: "generateRSAKey",
-			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+			generateKey: func(reader *bytes.Reader) (*rsa.PrivateKey, error) {
 				return generateRSAKey(reader, bits)
 			},
 		},

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"io"
 	"math/big"
 	"strconv"
 	"strings"
@@ -1864,4 +1865,140 @@ mQ00BF00000BCAD0000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000ABE000G0Dn000000000000000000iQ00BB0BAgAGBCG00000`
 	ReadArmoredKeyRing(strings.NewReader(data))
+}
+
+type DeterministicReader struct {
+	data []byte
+	// tracks the current read position in the data buffer
+	offset int
+}
+
+func (r *DeterministicReader) Read(p []byte) (n int, err error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	remaining := len(r.data) - r.offset
+	n = len(p)
+	if n > remaining {
+		n = remaining
+	}
+
+	copy(p, r.data[r.offset:r.offset+n])
+	r.offset += n
+
+	if r.offset >= len(r.data) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
+	// Hard-coded primes for a 2048-bit RSA key were taken from https://github.com/jam-awake/gpg-verify-bug
+	// using key with fingerprint: 2A25F94C4E482847305AB91E46EF00DD763B1D37
+	pHex := "00F9CC692674BE8A88092ADD770579E250871510B95057FA753DB79090CD72D3A6CE95BE6B8A632EB3F1D535C593F1804133441AD20D158848B5C2683B653C95F2844E5E168922BC2FF26D3F83F2CA76D29908C7E7BEA46F55C591978824C06999F362203B1EBFF457FF4232BA9ACB7AF4AA13DC5323E8DF5783C3F9DD0784F483"
+	qHex := "00D5FBCC013D18F2F98C4D52E8D69074803AE89E98ABAE93F8BB063F821C2E0AE652DB15180E5D659C7ABFF69DAD6D6C4EFB041FA21E3E3159E340131ED7962AFE260DA2DB570B21F49ACA3F722327BB1644FF4058CB9AA6B1ED06D9B82A36988780F175D33401F2D80AF831F42829DE914B8F68A8F98457950B8300E63290551F"
+
+	p := new(big.Int)
+	p.SetString(pHex, 16)
+
+	q := new(big.Int)
+	q.SetString(qHex, 16)
+
+	// Ensure RFC 9580's `p < q` requirement is NOT satisfied initially
+	if p.Cmp(q) == -1 {
+		t.Fatal(fmt.Printf("Expected `p < q` constraint to be unsatisfied. \np: %d\nq: %d\n", p, q))
+	}
+
+	bits := 2048
+	primeSize := bits / 8
+
+	createReader := func() *DeterministicReader {
+		readerBuffer := make([]byte, primeSize*2)
+		p.FillBytes(readerBuffer[primeSize:])
+		q.FillBytes(readerBuffer[:primeSize])
+		return &DeterministicReader{
+			data:   readerBuffer,
+			offset: 0,
+		}
+	}
+
+	verifyRSAKey := func(t *testing.T, key *rsa.PrivateKey, err error) {
+		t.Helper()
+
+		if err != nil {
+			t.Fatalf("Failed to generate RSA key: %v", err)
+		}
+
+		if key == nil {
+			t.Fatal("Generated key is nil")
+		}
+
+		if len(key.Primes) != 2 {
+			t.Fatalf("Expected 2 primes, got %d", len(key.Primes))
+		}
+
+		if key.Primes[0].Cmp(key.Primes[1]) != -1 {
+			t.Fatal("Prime in p slot should be less than prime in q slot")
+		}
+
+		pPrime := key.Primes[1]
+		qPrime := key.Primes[0]
+		if p.Cmp(pPrime) != 0 || q.Cmp(qPrime) != 0 {
+			t.Fatalf(
+				"Expected outputted primes to match inputted ones.\n"+
+					"p:  %d\n"+
+					"p': %d\n"+
+					"q:  %d\n"+
+					"q': %d",
+				p,
+				pPrime,
+				q,
+				qPrime,
+			)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		generateKey func(reader *DeterministicReader) (*rsa.PrivateKey, error)
+	}{
+		{
+			name: "generateRSAKeyWithPrimes",
+			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+				noPrepopulatedPrimes := []*big.Int{}
+				return generateRSAKeyWithPrimes(reader, 2, bits, noPrepopulatedPrimes)
+			},
+		},
+		{
+			name: "generateRSAKey",
+			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+				return generateRSAKey(reader, bits)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			for i := 0; i < 20; i++ {
+				reader := createReader()
+				key, err := testCase.generateKey(reader)
+
+				if err == io.ErrUnexpectedEOF {
+					t.Logf("Failed to generate key on attempt %d. "+
+						// In other words, the outputted integer didn't pass the ProbablyPrime test.
+						"Could not find two valid primes in the buffer before it ran out of data. "+
+						"Retrying...", i)
+					continue
+				}
+				verifyRSAKey(t, key, err)
+				break
+			}
+		})
+	}
 }

--- a/openpgp/v2/key_generation.go
+++ b/openpgp/v2/key_generation.go
@@ -359,7 +359,7 @@ func newSigner(config *packet.Config) (signer interface{}, err error) {
 			config.RSAPrimes = config.RSAPrimes[2:]
 			return generateRSAKeyWithPrimes(config.Random(), 2, bits, primes)
 		}
-		return rsa.GenerateKey(config.Random(), bits)
+		return generateRSAKey(config.Random(), bits)
 	case packet.PubKeyAlgoEdDSA:
 		if config.V6() {
 			// Implementations MUST NOT accept or generate v6 key material
@@ -417,7 +417,7 @@ func newDecrypter(config *packet.Config) (decrypter interface{}, err error) {
 			config.RSAPrimes = config.RSAPrimes[2:]
 			return generateRSAKeyWithPrimes(config.Random(), 2, bits, primes)
 		}
-		return rsa.GenerateKey(config.Random(), bits)
+		return generateRSAKey(config.Random(), bits)
 	case packet.PubKeyAlgoEdDSA, packet.PubKeyAlgoECDSA:
 		fallthrough // When passing EdDSA or ECDSA, we generate an ECDH subkey
 	case packet.PubKeyAlgoECDH:
@@ -447,6 +447,22 @@ func newDecrypter(config *packet.Config) (decrypter interface{}, err error) {
 }
 
 var bigOne = big.NewInt(1)
+
+// generateRSAKey generates an RSA keypair and ensures that p < q as required by RFC 9580.
+func generateRSAKey(random io.Reader, bits int) (*rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(random, bits)
+	if err != nil {
+		return nil, err
+	}
+	// RFC 9580 section 5.5.5.1 requires p < q for RSA keys.
+	// The Go standard library does not guarantee this, so we swap if needed
+	// and recompute the precomputed values.
+	if len(key.Primes) == 2 && key.Primes[0].Cmp(key.Primes[1]) > 0 {
+		key.Primes[0], key.Primes[1] = key.Primes[1], key.Primes[0]
+		key.Precompute()
+	}
+	return key, nil
+}
 
 // generateRSAKeyWithPrimes generates a multi-prime RSA keypair of the
 // given bit size, using the given random source and prepopulated primes.
@@ -529,6 +545,11 @@ NextSetOfPrimes:
 			priv.N = n
 			break
 		}
+	}
+
+	// RFC 9580 section 5.5.5.1 requires p < q for RSA keys.
+	if len(priv.Primes) == 2 && priv.Primes[0].Cmp(priv.Primes[1]) > 0 {
+		priv.Primes[0], priv.Primes[1] = priv.Primes[1], priv.Primes[0]
 	}
 
 	priv.Precompute()

--- a/openpgp/v2/keys_test.go
+++ b/openpgp/v2/keys_test.go
@@ -2111,37 +2111,6 @@ func TestEncryptionKeyError(t *testing.T) {
 	}
 }
 
-type DeterministicReader struct {
-	data []byte
-	// tracks the current read position in the data buffer
-	offset int
-}
-
-func (r *DeterministicReader) Read(p []byte) (n int, err error) {
-	if r.offset >= len(r.data) {
-		return 0, io.EOF
-	}
-
-	if len(p) == 0 {
-		return 0, nil
-	}
-
-	remaining := len(r.data) - r.offset
-	n = len(p)
-	if n > remaining {
-		n = remaining
-	}
-
-	copy(p, r.data[r.offset:r.offset+n])
-	r.offset += n
-
-	if r.offset >= len(r.data) {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
 func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 	// Hard-coded primes for a 2048-bit RSA key were taken from https://github.com/jam-awake/gpg-verify-bug
 	// using key with fingerprint: 2A25F94C4E482847305AB91E46EF00DD763B1D37
@@ -2162,14 +2131,11 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 	bits := 2048
 	primeSize := bits / 8
 
-	createReader := func() *DeterministicReader {
+	createReader := func() *bytes.Reader {
 		readerBuffer := make([]byte, primeSize*2)
 		p.FillBytes(readerBuffer[primeSize:])
 		q.FillBytes(readerBuffer[:primeSize])
-		return &DeterministicReader{
-			data:   readerBuffer,
-			offset: 0,
-		}
+		return bytes.NewReader(readerBuffer)
 	}
 
 	verifyRSAKey := func(t *testing.T, key *rsa.PrivateKey, err error) {
@@ -2210,18 +2176,18 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		generateKey func(reader *DeterministicReader) (*rsa.PrivateKey, error)
+		generateKey func(reader *bytes.Reader) (*rsa.PrivateKey, error)
 	}{
 		{
 			name: "generateRSAKeyWithPrimes",
-			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+			generateKey: func(reader *bytes.Reader) (*rsa.PrivateKey, error) {
 				noPrepopulatedPrimes := []*big.Int{}
 				return generateRSAKeyWithPrimes(reader, 2, bits, noPrepopulatedPrimes)
 			},
 		},
 		{
 			name: "generateRSAKey",
-			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+			generateKey: func(reader *bytes.Reader) (*rsa.PrivateKey, error) {
 				return generateRSAKey(reader, bits)
 			},
 		},

--- a/openpgp/v2/keys_test.go
+++ b/openpgp/v2/keys_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"io"
 	"math/big"
 	"strconv"
 	"strings"
@@ -2107,5 +2108,141 @@ func TestEncryptionKeyError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no encryption-capable key found (no key flags or invalid algorithm)") {
 		t.Fatal("wrong error")
+	}
+}
+
+type DeterministicReader struct {
+	data []byte
+	// tracks the current read position in the data buffer
+	offset int
+}
+
+func (r *DeterministicReader) Read(p []byte) (n int, err error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	remaining := len(r.data) - r.offset
+	n = len(p)
+	if n > remaining {
+		n = remaining
+	}
+
+	copy(p, r.data[r.offset:r.offset+n])
+	r.offset += n
+
+	if r.offset >= len(r.data) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
+	// Hard-coded primes for a 2048-bit RSA key were taken from https://github.com/jam-awake/gpg-verify-bug
+	// using key with fingerprint: 2A25F94C4E482847305AB91E46EF00DD763B1D37
+	pHex := "00F9CC692674BE8A88092ADD770579E250871510B95057FA753DB79090CD72D3A6CE95BE6B8A632EB3F1D535C593F1804133441AD20D158848B5C2683B653C95F2844E5E168922BC2FF26D3F83F2CA76D29908C7E7BEA46F55C591978824C06999F362203B1EBFF457FF4232BA9ACB7AF4AA13DC5323E8DF5783C3F9DD0784F483"
+	qHex := "00D5FBCC013D18F2F98C4D52E8D69074803AE89E98ABAE93F8BB063F821C2E0AE652DB15180E5D659C7ABFF69DAD6D6C4EFB041FA21E3E3159E340131ED7962AFE260DA2DB570B21F49ACA3F722327BB1644FF4058CB9AA6B1ED06D9B82A36988780F175D33401F2D80AF831F42829DE914B8F68A8F98457950B8300E63290551F"
+
+	p := new(big.Int)
+	p.SetString(pHex, 16)
+
+	q := new(big.Int)
+	q.SetString(qHex, 16)
+
+	// Ensure RFC 9580's `p < q` requirement is NOT satisfied initially
+	if p.Cmp(q) == -1 {
+		t.Fatal(fmt.Printf("Expected `p < q` constraint to be unsatisfied. \np: %d\nq: %d\n", p, q))
+	}
+
+	bits := 2048
+	primeSize := bits / 8
+
+	createReader := func() *DeterministicReader {
+		readerBuffer := make([]byte, primeSize*2)
+		p.FillBytes(readerBuffer[primeSize:])
+		q.FillBytes(readerBuffer[:primeSize])
+		return &DeterministicReader{
+			data:   readerBuffer,
+			offset: 0,
+		}
+	}
+
+	verifyRSAKey := func(t *testing.T, key *rsa.PrivateKey, err error) {
+		t.Helper()
+
+		if err != nil {
+			t.Fatalf("Failed to generate RSA key: %v", err)
+		}
+
+		if key == nil {
+			t.Fatal("Generated key is nil")
+		}
+
+		if len(key.Primes) != 2 {
+			t.Fatalf("Expected 2 primes, got %d", len(key.Primes))
+		}
+
+		if key.Primes[0].Cmp(key.Primes[1]) != -1 {
+			t.Fatal("Prime in p slot should be less than prime in q slot")
+		}
+
+		pPrime := key.Primes[1]
+		qPrime := key.Primes[0]
+		if p.Cmp(pPrime) != 0 || q.Cmp(qPrime) != 0 {
+			t.Fatalf(
+				"Expected outputted primes to match inputted ones.\n"+
+					"p:  %d\n"+
+					"p': %d\n"+
+					"q:  %d\n"+
+					"q': %d",
+				p,
+				pPrime,
+				q,
+				qPrime,
+			)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		generateKey func(reader *DeterministicReader) (*rsa.PrivateKey, error)
+	}{
+		{
+			name: "generateRSAKeyWithPrimes",
+			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+				noPrepopulatedPrimes := []*big.Int{}
+				return generateRSAKeyWithPrimes(reader, 2, bits, noPrepopulatedPrimes)
+			},
+		},
+		{
+			name: "generateRSAKey",
+			generateKey: func(reader *DeterministicReader) (*rsa.PrivateKey, error) {
+				return generateRSAKey(reader, bits)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			for i := 0; i < 20; i++ {
+				reader := createReader()
+				key, err := testCase.generateKey(reader)
+
+				if err == io.ErrUnexpectedEOF {
+					t.Logf("Failed to generate key on attempt %d. "+
+						// In other words, the outputted integer didn't pass the ProbablyPrime test.
+						"Could not find two valid primes in the buffer before it ran out of data. "+
+						"Retrying...", i)
+					continue
+				}
+				verifyRSAKey(t, key, err)
+				break
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Adds a wrapper around `rsa.GenerateKey` that swaps the P and Q primes if P > Q and recomputes the precomputed values
- Applies this change to `generateRSAKeyWithPrimes` as well but only if the key has 2 prime numbers because I don't know what's safe to do in this context.

Questions I have:
1. Given the duplication of these two functions' implementations, should this be consolidated somewhere? Or is it fine to have the duplication?
2. I'm not sure what tests should be written that verifies this work, so I've omitted those. Is that fine?

Fixes #184 

Also, per your contributing guidelines:
> 2. I certify that the contribution was created in whole by me

I asked an AI to investigate the problem and attempt to fix it. I then reviewed what it produced and edited it to something that I feel like I would have written. I'm not familiar with Go or cryptography, but this issue seems small enough that this method seemed appropriate.