### PR TITLE
feat: Add ecdh.Decapsulator interface for hardware token decryption

### DIFF
--- a/openpgp/ecdh/ecdh.go
+++ b/openpgp/ecdh/ecdh.go
@@ -118,15 +118,58 @@ func Encrypt(random io.Reader, pub *PublicKey, msg, curveOID, fingerprint []byte
 
 }
 
+// Decapsulator allows ECDH decapsulation to be performed by an external
+// implementation, such as a hardware token (YubiKey, OpenPGP smartcard).
+// The library calls Decaps during session key decryption; implementations
+// perform the ECDH key agreement and return the raw shared secret.
+// The library handles KDF and AES key unwrap internally.
+type Decapsulator interface {
+	// Decaps performs ECDH key agreement using the given ephemeral
+	// public key point and returns the raw shared secret.
+	Decaps(ephemeral []byte) (sharedSecret []byte, err error)
+}
+
 func Decrypt(priv *PrivateKey, vsG, c, curveOID, fingerprint []byte) (msg []byte, err error) {
-	var m []byte
 	zb, err := priv.PublicKey.curve.Decaps(priv.curve.UnmarshalBytePoint(vsG), priv.D)
+	if err != nil {
+		return nil, err
+	}
+
+	return decryptWithSharedSecret(&priv.PublicKey, zb, c, curveOID, fingerprint)
+}
+
+// DecryptWithDecapsulator decrypts an ECDH-encrypted session key using an
+// external Decapsulator to perform the key agreement step. This supports
+// hardware tokens (YubiKey, OpenPGP smartcard) that perform ECDH internally
+// and return only the raw shared secret, without exposing the private key.
+//
+// The Decapsulator is called with the unmarshalled ephemeral public key
+// point from the PKESK packet. The KDF (RFC 6637 §8) and AES key unwrap
+// (RFC 3394) steps are handled internally by this function.
+func DecryptWithDecapsulator(decapsulator Decapsulator, pub *PublicKey, vsG, c, curveOID, fingerprint []byte) (msg []byte, err error) {
+	ephemeral := pub.curve.UnmarshalBytePoint(vsG)
+	if len(ephemeral) == 0 {
+		return nil, errors.New("ecdh: invalid ephemeral public key point")
+	}
+	zb, err := decapsulator.Decaps(ephemeral)
+	if err != nil {
+		return nil, err
+	}
+
+	return decryptWithSharedSecret(pub, zb, c, curveOID, fingerprint)
+}
+
+// decryptWithSharedSecret completes ECDH decryption given a pre-computed
+// shared secret, performing KDF and AES key unwrap.
+func decryptWithSharedSecret(pub *PublicKey, zb, c, curveOID, fingerprint []byte) ([]byte, error) {
+	var m []byte
+	var err error
 
 	// Try buildKey three times to workaround an old bug, see comments in buildKey.
 	for i := 0; i < 3; i++ {
 		var z []byte
 		// RFC6637 §8: "Compute Z = KDF( S, Z_len, Param );"
-		z, err = buildKey(&priv.PublicKey, zb, curveOID, fingerprint, i == 1, i == 2)
+		z, err = buildKey(pub, zb, curveOID, fingerprint, i == 1, i == 2)
 		if err != nil {
 			return nil, err
 		}

--- a/openpgp/ecdh/ecdh_test.go
+++ b/openpgp/ecdh/ecdh_test.go
@@ -32,6 +32,7 @@ func TestCurves(t *testing.T) {
 
 			priv := testGenerate(t, ECDHCurve)
 			testEncryptDecrypt(t, priv, curve.Oid.Bytes(), testFingerprint)
+			testDecryptWithDecapsulator(t, priv, curve.Oid.Bytes(), testFingerprint)
 			testValidation(t, priv)
 
 			// Needs fresh key
@@ -70,6 +71,46 @@ func testEncryptDecrypt(t *testing.T, priv *PrivateKey, oid, fingerprint []byte)
 
 	if !bytes.Equal(message2, message) {
 		t.Errorf("decryption failed, got: %x, want: %x", message2, message)
+	}
+}
+
+// testDecapsulator wraps a real private key, simulating a hardware token
+// that performs ECDH key agreement internally without exposing the scalar.
+type testDecapsulator struct {
+	priv        *PrivateKey
+	decapsCount int
+}
+
+func (d *testDecapsulator) Decaps(ephemeral []byte) ([]byte, error) {
+	d.decapsCount++
+	return d.priv.PublicKey.GetCurve().Decaps(ephemeral, d.priv.D)
+}
+
+// testDecryptWithDecapsulator simulates the hardware token flow:
+// 1. Encrypt a message normally
+// 2. Decrypt via a Decapsulator (simulating what a hardware token does)
+// 3. Verify the decrypted message matches the original
+func testDecryptWithDecapsulator(t *testing.T, priv *PrivateKey, oid, fingerprint []byte) {
+	message := []byte("hello world")
+
+	vsG, wrappedKey, err := Encrypt(rand.Reader, &priv.PublicKey, message, oid, fingerprint)
+	if err != nil {
+		t.Fatalf("error encrypting: %s", err)
+	}
+
+	decapsulator := &testDecapsulator{priv: priv}
+
+	decrypted, err := DecryptWithDecapsulator(decapsulator, &priv.PublicKey, vsG, wrappedKey, oid, fingerprint)
+	if err != nil {
+		t.Fatalf("error in DecryptWithDecapsulator: %s", err)
+	}
+
+	if !bytes.Equal(decrypted, message) {
+		t.Errorf("DecryptWithDecapsulator failed, got: %x, want: %x", decrypted, message)
+	}
+
+	if decapsulator.decapsCount != 1 {
+		t.Errorf("expected Decaps to be called once, got %d", decapsulator.decapsCount)
 	}
 }
 

--- a/openpgp/packet/encrypted_key.go
+++ b/openpgp/packet/encrypted_key.go
@@ -186,7 +186,13 @@ func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
 			// For v5 the, the fingerprint must be restricted to 20 bytes
 			fp = fp[:20]
 		}
-		b, err = ecdh.Decrypt(priv.PrivateKey.(*ecdh.PrivateKey), vsG, m, oid, fp)
+		// Supports both *ecdh.PrivateKey and ecdh.Decapsulator (for hardware tokens)
+		if decapsulator, ok := priv.PrivateKey.(ecdh.Decapsulator); ok {
+			ecdhPub := priv.PublicKey.PublicKey.(*ecdh.PublicKey)
+			b, err = ecdh.DecryptWithDecapsulator(decapsulator, ecdhPub, vsG, m, oid, fp)
+		} else {
+			b, err = ecdh.Decrypt(priv.PrivateKey.(*ecdh.PrivateKey), vsG, m, oid, fp)
+		}
 	case PubKeyAlgoX25519:
 		b, err = x25519.Decrypt(priv.PrivateKey.(*x25519.PrivateKey), e.ephemeralPublicX25519, e.encryptedSession)
 	case PubKeyAlgoX448:

--- a/openpgp/packet/encrypted_key_test.go
+++ b/openpgp/packet/encrypted_key_test.go
@@ -14,8 +14,12 @@ import (
 	"time"
 
 	"crypto"
+	"crypto/rand"
 	"crypto/rsa"
 
+	"github.com/ProtonMail/go-crypto/openpgp/ecdh"
+	"github.com/ProtonMail/go-crypto/openpgp/internal/algorithm"
+	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
 	"github.com/ProtonMail/go-crypto/openpgp/x25519"
 	"github.com/ProtonMail/go-crypto/openpgp/x448"
 )
@@ -313,6 +317,74 @@ func TestEncryptingEncryptedKeyXAlgorithms(t *testing.T) {
 		if keyHex != expectedKeyHex {
 			t.Errorf("bad key, got %s want %s", keyHex, expectedKeyHex)
 		}
+	}
+}
+
+// ecdhDecapsulator wraps a real ECDH private key, simulating a hardware
+// token that performs key agreement without exposing the private scalar.
+type ecdhDecapsulator struct {
+	priv        *ecdh.PrivateKey
+	decapsCount int
+}
+
+func (d *ecdhDecapsulator) Decaps(ephemeral []byte) ([]byte, error) {
+	d.decapsCount++
+	return d.priv.GetCurve().Decaps(ephemeral, d.priv.D)
+}
+
+func TestECDHDecapsulator(t *testing.T) {
+	key := []byte{1, 2, 3, 4}
+	kdf := ecdh.KDF{
+		Hash:   algorithm.SHA256,
+		Cipher: algorithm.AES128,
+	}
+	ecdhKey, err := ecdh.GenerateKey(rand.Reader, ecc.NewCurve25519(), kdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrappedKey := NewECDHPrivateKey(time.Now(), ecdhKey)
+	wrappedKeyPub := &wrappedKey.PublicKey
+
+	buf := new(bytes.Buffer)
+	err = SerializeEncryptedKeyAEAD(buf, wrappedKeyPub, CipherAES128, false, key, nil)
+	if err != nil {
+		t.Fatalf("error writing encrypted key packet: %s", err)
+	}
+
+	p, err := Read(buf)
+	if err != nil {
+		t.Fatalf("error from Read: %s", err)
+	}
+	ek, ok := p.(*EncryptedKey)
+	if !ok {
+		t.Fatalf("didn't parse an EncryptedKey, got %#v", p)
+	}
+
+	// Create a PrivateKey with a Decapsulator instead of *ecdh.PrivateKey
+	decapsulator := &ecdhDecapsulator{priv: ecdhKey}
+	customKeyPriv := &PrivateKey{
+		PublicKey:  *wrappedKeyPub,
+		PrivateKey: decapsulator,
+	}
+
+	err = ek.Decrypt(customKeyPriv, nil)
+	if err != nil {
+		t.Fatalf("error from Decrypt with Decapsulator: %s", err)
+	}
+
+	if ek.CipherFunc != CipherAES128 {
+		t.Errorf("unexpected CipherFunc: got %d, want %d", ek.CipherFunc, CipherAES128)
+	}
+
+	keyHex := fmt.Sprintf("%x", ek.Key)
+	expectedKeyHex := fmt.Sprintf("%x", key)
+	if keyHex != expectedKeyHex {
+		t.Errorf("bad key, got %s want %s", keyHex, expectedKeyHex)
+	}
+
+	if decapsulator.decapsCount != 1 {
+		t.Errorf("expected Decaps to be called once, got %d", decapsulator.decapsCount)
 	}
 }
 

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -43,7 +43,8 @@ type PrivateKey struct {
 	s2k           func(out, in []byte)
 	aead          AEADMode // only relevant if S2KAEAD is enabled
 	// An *{rsa|dsa|elgamal|ecdh|ecdsa|ed25519|ed448}.PrivateKey or
-	// crypto.Signer/crypto.Decrypter (Decryptor RSA only).
+	// crypto.Signer/crypto.Decrypter (RSA only) or
+	// ecdh.Decapsulator (ECDH hardware token decryption).
 	PrivateKey interface{}
 	iv         []byte
 


### PR DESCRIPTION
## Summary

Adds a `Decapsulator` interface to the `ecdh` package, allowing ECDH key agreement to be performed by an external implementation such as a hardware token (YubiKey, OpenPGP smartcard). This mirrors the existing `crypto.Decrypter` pattern already used for RSA hardware token support.

This is a revised approach based on @twiss's [feedback](https://github.com/ProtonMail/go-crypto/pull/307#issuecomment-4175903120) — using an interface-based design instead of exposing raw MPI getters.

## Design

Hardware tokens perform ECDH key agreement internally via PSO:DECIPHER and return only the raw shared secret, never exposing the private scalar. The new `Decapsulator` interface captures exactly this:

```go
type Decapsulator interface {
    Decaps(ephemeral []byte) (sharedSecret []byte, err error)
}
```

The library handles unmarshalling the ephemeral point, KDF (RFC 6637 §8), and AES key unwrap (RFC 3394) internally — the `Decapsulator` only performs the key agreement step, matching what the hardware actually does.

Integration follows the same pattern as RSA's `crypto.Decrypter`: set a `Decapsulator` as the `PrivateKey` field of `packet.PrivateKey`, and `EncryptedKey.Decrypt()` dispatches to it automatically.

### Why `Decapsulator` over a custom `ECDHCurve`

- `ECDHCurve` is in `openpgp/internal/ecc` — external callers can't import or implement it
- `ECDHCurve.Decaps(ephemeral, secret []byte)` takes the private scalar as a parameter, which hardware tokens don't have — the interface signature is semantically wrong for this use case
- `ECDHCurve` has 8 methods; `Decapsulator` has 1
- The name `Decapsulator` is deliberately generic (not `ECDHDecapsulator`) to allow reuse if x25519/x448 gain similar support later

## Changes

- `ecdh/ecdh.go`: Add `Decapsulator` interface, `DecryptWithDecapsulator()`, refactor `Decrypt()` to share KDF/unwrap logic via internal helper
- `packet/encrypted_key.go`: ECDH case checks for `ecdh.Decapsulator` before falling back to `*ecdh.PrivateKey`
- `packet/private_key.go`: Updated `PrivateKey` field comment

No existing behaviour is changed. All new code is additive.

## Test plan

- [x] `testDecryptWithDecapsulator` — encrypt → decrypt via Decapsulator roundtrip across all 9 ECDH curves (P-256, P-384, P-521, secp256k1, curve25519, x448, brainpoolP256r1, brainpoolP384r1, brainpoolP512r1)
- [x] `TestECDHDecapsulator` — packet-level roundtrip: serialize encrypted key → decrypt with Decapsulator-backed `PrivateKey` → verify session key
- [x] Full test suite passes (`go test ./...` — all 22 packages)

Relates to ProtonMail/gopenpgp#174.