### PR TITLE
Fix RSA precompute after prime swap

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -379,6 +379,7 @@ func generateRSAKey(random io.Reader, bits int) (*rsa.PrivateKey, error) {
 	// and recompute the precomputed values.
 	if len(key.Primes) == 2 && key.Primes[0].Cmp(key.Primes[1]) > 0 {
 		key.Primes[0], key.Primes[1] = key.Primes[1], key.Primes[0]
+		key.Precomputed = rsa.PrecomputedValues{}
 		key.Precompute()
 	}
 	return key, nil

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -1912,6 +1912,13 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 		if key.Primes[0].Cmp(key.Primes[1]) != -1 {
 			t.Fatal("Prime in p slot should be less than prime in q slot")
 		}
+		if err := key.Validate(); err != nil {
+			t.Fatalf("Generated key failed validation: %v", err)
+		}
+		digest := make([]byte, crypto.SHA256.Size())
+		if _, err := key.Sign(rand.Reader, digest, crypto.SHA256); err != nil {
+			t.Fatalf("Generated key failed signing: %v", err)
+		}
 
 		pPrime := key.Primes[1]
 		qPrime := key.Primes[0]

--- a/openpgp/v2/key_generation.go
+++ b/openpgp/v2/key_generation.go
@@ -459,6 +459,7 @@ func generateRSAKey(random io.Reader, bits int) (*rsa.PrivateKey, error) {
 	// and recompute the precomputed values.
 	if len(key.Primes) == 2 && key.Primes[0].Cmp(key.Primes[1]) > 0 {
 		key.Primes[0], key.Primes[1] = key.Primes[1], key.Primes[0]
+		key.Precomputed = rsa.PrecomputedValues{}
 		key.Precompute()
 	}
 	return key, nil

--- a/openpgp/v2/keys_test.go
+++ b/openpgp/v2/keys_test.go
@@ -2156,6 +2156,13 @@ func TestGenerateRSAKeyPLessThanQ(t *testing.T) {
 		if key.Primes[0].Cmp(key.Primes[1]) != -1 {
 			t.Fatal("Prime in p slot should be less than prime in q slot")
 		}
+		if err := key.Validate(); err != nil {
+			t.Fatalf("Generated key failed validation: %v", err)
+		}
+		digest := make([]byte, crypto.SHA256.Size())
+		if _, err := key.Sign(rand.Reader, digest, crypto.SHA256); err != nil {
+			t.Fatalf("Generated key failed signing: %v", err)
+		}
 
 		pPrime := key.Primes[1]
 		qPrime := key.Primes[0]


### PR DESCRIPTION
PR 305 swaps RSA primes to satisfy the OpenPGP P < Q constraint, but rsa.GenerateKey has already populated CRT precomputed values for the original prime order. Reset Precomputed before calling Precompute after a swap so Validate and Sign use CRT values that match the new order.
Also extends the existing P < Q regression tests to assert generated keys validate and can sign.
Tested:

- GOCACHE=/tmp/go-crypto-build-cache GOMODCACHE=/tmp/go-crypto-mod-cache go test ./openpgp -run TestGenerateRSAKeyPLessThanQ -count=1
- GOCACHE=/tmp/go-crypto-build-cache GOMODCACHE=/tmp/go-crypto-mod-cache go test ./openpgp/v2 -run TestGenerateRSAKeyPLessThanQ -count=1
- CGO_ENABLED=0 GOCACHE=/tmp/go-crypto-build-cache GOMODCACHE=/tmp/go-crypto-mod-cache go test ./...