### PR TITLE
guard nil issuer key id on v2 message read path

### DIFF
--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -311,7 +311,11 @@ func newSignatureCandidate(ops *packet.OnePassSignature) (sigCandidate *Signatur
 	return
 }
 
-func newSignatureCandidateFromSignature(sig *packet.Signature) (sigCandidate *SignatureCandidate) {
+func newSignatureCandidateFromSignature(sig *packet.Signature) (sigCandidate *SignatureCandidate, err error) {
+	if sig.IssuerKeyId == nil {
+		return nil, errors.StructuralError("signature doesn't have an issuer")
+	}
+
 	sigCandidate = &SignatureCandidate{
 		SigType:           sig.SigType,
 		HashAlgorithm:     sig.Hash,
@@ -394,10 +398,10 @@ FindLiteralData:
 			md.SignatureCandidates = append([]*SignatureCandidate{sigCandidate}, md.SignatureCandidates...)
 		case *packet.Signature:
 			// Old style signature i.e., sig | literal
-			if p.IssuerKeyId == nil {
-				return nil, errors.StructuralError("signature doesn't have an issuer")
+			sigCandidate, err := newSignatureCandidateFromSignature(p)
+			if err != nil {
+				return nil, err
 			}
-			sigCandidate := newSignatureCandidateFromSignature(p)
 			md.IsSigned = true
 			if keyring != nil {
 				keys := keyring.EntitiesById(sigCandidate.IssuerKeyId)
@@ -718,10 +722,10 @@ func verifyDetachedSignatureReader(keyring KeyRing, signed, signature io.Reader,
 		if !ok {
 			continue
 		}
-		if sig.IssuerKeyId == nil {
-			return nil, errors.StructuralError("signature doesn't have an issuer")
+		candidate, err := newSignatureCandidateFromSignature(sig)
+		if err != nil {
+			return nil, err
 		}
-		candidate := newSignatureCandidateFromSignature(sig)
 		md.SignatureCandidates = append(md.SignatureCandidates, candidate)
 
 		keys := keyring.EntitiesById(candidate.IssuerKeyId)

--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -347,6 +347,7 @@ func (sc *SignatureCandidate) validate() bool {
 		sc.SigType == correspondingSig.SigType &&
 		sc.HashAlgorithm == correspondingSig.Hash &&
 		sc.PubKeyAlgo == correspondingSig.PubKeyAlgo &&
+		correspondingSig.IssuerKeyId != nil &&
 		sc.IssuerKeyId == *correspondingSig.IssuerKeyId
 }
 
@@ -393,6 +394,9 @@ FindLiteralData:
 			md.SignatureCandidates = append([]*SignatureCandidate{sigCandidate}, md.SignatureCandidates...)
 		case *packet.Signature:
 			// Old style signature i.e., sig | literal
+			if p.IssuerKeyId == nil {
+				return nil, errors.StructuralError("signature doesn't have an issuer")
+			}
 			sigCandidate := newSignatureCandidateFromSignature(p)
 			md.IsSigned = true
 			if keyring != nil {

--- a/openpgp/v2/read_security_test.go
+++ b/openpgp/v2/read_security_test.go
@@ -1,0 +1,61 @@
+package v2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+func packetLength(n int) []byte {
+	switch {
+	case n < 192:
+		return []byte{byte(n)}
+	case n < 8384:
+		n -= 192
+		return []byte{byte(n>>8) + 192, byte(n)}
+	default:
+		return []byte{0xff, byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	}
+}
+
+func wrapPacket(tag byte, body []byte) []byte {
+	out := []byte{0xc0 | tag}
+	out = append(out, packetLength(len(body))...)
+	return append(out, body...)
+}
+
+func sigNoIssuer() []byte {
+	creation := []byte{0x05, 0x02, 0x00, 0x00, 0x00, 0x01}
+	var body bytes.Buffer
+	body.WriteByte(0x04)
+	body.WriteByte(0x00)
+	body.WriteByte(0x01)
+	body.WriteByte(0x08)
+	binary.Write(&body, binary.BigEndian, uint16(len(creation)))
+	body.Write(creation)
+	binary.Write(&body, binary.BigEndian, uint16(0))
+	body.Write([]byte{0x00, 0x00})
+	body.Write([]byte{0x00, 0x00})
+	return wrapPacket(2, body.Bytes())
+}
+
+func literalPacket(data []byte) []byte {
+	var body bytes.Buffer
+	body.WriteByte('b')
+	body.WriteByte(0x00)
+	body.Write([]byte{0x00, 0x00, 0x00, 0x00})
+	body.Write(data)
+	return wrapPacket(11, body.Bytes())
+}
+
+func TestReadMessageNilIssuerNoPanic(t *testing.T) {
+	msg := append(sigNoIssuer(), literalPacket([]byte("hello"))...)
+	md, err := ReadMessage(bytes.NewReader(msg), nil, nil, nil)
+	if err == nil {
+		if md != nil && md.UnverifiedBody != nil {
+			io.Copy(io.Discard, md.UnverifiedBody)
+		}
+		t.Fatal("expected an error for signature without issuer, got nil")
+	}
+}


### PR DESCRIPTION
A signature packet with no issuer key id causes a nil pointer dereference while reading a v2 message, so untrusted input can panic the reader. This checks the issuer key id before it is dereferenced and rejects the signature instead of panicking.