### PR TITLE
Don't panic on unknown AEAD mode in v5/v6 SKESK packets

### DIFF
--- a/openpgp/internal/algorithm/aead.go
+++ b/openpgp/internal/algorithm/aead.go
@@ -4,8 +4,11 @@ package algorithm
 
 import (
 	"crypto/cipher"
+	"strconv"
+
 	"github.com/ProtonMail/go-crypto/eax"
 	"github.com/ProtonMail/go-crypto/ocb"
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
 )
 
 // AEADMode defines the Authenticated Encryption with Associated Data mode of
@@ -48,8 +51,7 @@ func (mode AEADMode) NonceLength() int {
 }
 
 // New returns a fresh instance of the given mode
-func (mode AEADMode) New(block cipher.Block) (alg cipher.AEAD) {
-	var err error
+func (mode AEADMode) New(block cipher.Block) (alg cipher.AEAD, err error) {
 	switch mode {
 	case AEADModeEAX:
 		alg, err = eax.NewEAX(block)
@@ -57,9 +59,8 @@ func (mode AEADMode) New(block cipher.Block) (alg cipher.AEAD) {
 		alg, err = ocb.NewOCB(block)
 	case AEADModeGCM:
 		alg, err = cipher.NewGCM(block)
+	default:
+		err = errors.UnsupportedError("unknown aead mode: " + strconv.Itoa(int(mode)))
 	}
-	if err != nil {
-		panic(err.Error())
-	}
-	return alg
+	return alg, err
 }

--- a/openpgp/packet/aead_encrypted.go
+++ b/openpgp/packet/aead_encrypted.go
@@ -63,7 +63,11 @@ func (ae *AEADEncrypted) Decrypt(ciph CipherFunction, key []byte) (io.ReadCloser
 // decrypted bytes can be read (see aeadDecrypter.Read()).
 func (ae *AEADEncrypted) decrypt(key []byte) (io.ReadCloser, error) {
 	blockCipher := ae.cipher.new(key)
-	aead := ae.mode.new(blockCipher)
+	aead, err := ae.mode.new(blockCipher)
+	if err != nil {
+		return nil, err
+	}
+
 	// Carry the first tagLen bytes
 	chunkSize := decodeAEADChunkSize(ae.chunkSizeByte)
 	tagLen := ae.mode.TagLength()

--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -446,7 +446,10 @@ func SerializeAEADEncrypted(w io.Writer, key []byte, config *Config) (io.WriteCl
 		return nil, err
 	}
 	blockCipher := CipherFunction(config.Cipher()).new(key)
-	alg := aeadConf.Mode().new(blockCipher)
+	alg, err := aeadConf.Mode().new(blockCipher)
+	if err != nil {
+		return nil, err
+	}
 
 	chunkSize := decodeAEADChunkSize(aeadConf.ChunkSizeByte())
 	tagLen := alg.Overhead()

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -626,7 +626,7 @@ func (mode AEADMode) IsSupported() bool {
 }
 
 // new returns a fresh instance of the given mode.
-func (mode AEADMode) new(block cipher.Block) cipher.AEAD {
+func (mode AEADMode) new(block cipher.Block) (cipher.AEAD, error) {
 	return algorithm.AEADMode(mode).New(block)
 }
 

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -586,7 +586,10 @@ func (pk *PrivateKey) decrypt(decryptionKey []byte) error {
 	var data []byte
 	switch pk.s2kType {
 	case S2KAEAD:
-		aead := pk.aead.new(block)
+		aead, err := pk.aead.new(block)
+		if err != nil {
+			return err
+		}
 		additionalData, err := pk.additionalData()
 		if err != nil {
 			return err
@@ -738,7 +741,10 @@ func (pk *PrivateKey) encrypt(key []byte, params *s2k.Params, s2kType S2KType, c
 		if pk.aead == 0 {
 			return errors.StructuralError("aead mode is not set on key")
 		}
-		aead := pk.aead.new(block)
+		aead, err := pk.aead.new(block)
+		if err != nil {
+			return err
+		}
 		additionalData, err := pk.additionalData()
 		if err != nil {
 			return err

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -158,7 +158,10 @@ func (ske *SymmetricKeyEncrypted) decryptV4(key []byte) ([]byte, CipherFunction,
 
 func (ske *SymmetricKeyEncrypted) aeadDecrypt(version int, key []byte) ([]byte, error) {
 	adata := []byte{0xc3, byte(version), byte(ske.CipherFunc), byte(ske.Mode)}
-	aead := getEncryptedKeyAeadInstance(ske.CipherFunc, ske.Mode, key, adata, version)
+	aead, err := getEncryptedKeyAeadInstance(ske.CipherFunc, ske.Mode, key, adata, version)
+	if err != nil {
+		return nil, err
+	}
 
 	plaintextKey, err := aead.Open(nil, ske.iv, ske.encryptedKey, adata)
 	if err != nil {
@@ -291,7 +294,11 @@ func SerializeSymmetricKeyEncryptedAEADReuseKey(w io.Writer, sessionKey []byte, 
 	case 5, 6:
 		mode := config.AEAD().Mode()
 		adata := []byte{0xc3, byte(version), byte(cipherFunc), byte(mode)}
-		aead := getEncryptedKeyAeadInstance(cipherFunc, mode, keyEncryptingKey, adata, version)
+		var aead cipher.AEAD
+		aead, err = getEncryptedKeyAeadInstance(cipherFunc, mode, keyEncryptingKey, adata, version)
+		if err != nil {
+			return
+		}
 
 		// Sample iv using random reader
 		iv := make([]byte, config.AEAD().Mode().IvLength())
@@ -315,7 +322,7 @@ func SerializeSymmetricKeyEncryptedAEADReuseKey(w io.Writer, sessionKey []byte, 
 	return
 }
 
-func getEncryptedKeyAeadInstance(c CipherFunction, mode AEADMode, inputKey, associatedData []byte, version int) (aead cipher.AEAD) {
+func getEncryptedKeyAeadInstance(c CipherFunction, mode AEADMode, inputKey, associatedData []byte, version int) (aead cipher.AEAD, err error) {
 	var blockCipher cipher.Block
 	if version > 5 {
 		hkdfReader := hkdf.New(sha256.New, inputKey, []byte{}, associatedData)

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -221,6 +221,50 @@ func TestSerializeSymmetricKeyEncryptedV6RandomizeSlow(t *testing.T) {
 	}
 }
 
+func TestSymmetricKeyEncryptedUnknownAEADMode(t *testing.T) {
+	const unknownMode = 0xff
+
+	var buf bytes.Buffer
+	passphrase := []byte("password")
+	config := &Config{
+		DefaultCipher: CipherAES128,
+		AEADConfig:    &AEADConfig{DefaultMode: AEADModeEAX},
+		S2KConfig:     &s2k.Config{S2KMode: s2k.IteratedSaltedS2K, PassphraseIsHighEntropy: true},
+	}
+
+	if _, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config); err != nil {
+		t.Fatalf("failed to serialize: %s", err)
+	}
+
+	// Replace the AEAD mode octet of the serialized packet with an unknown mode
+	serialized := buf.Bytes()
+	if serialized[5] != byte(AEADModeEAX) {
+		t.Fatalf("AEAD mode octet is %d (expected %d)", serialized[5], AEADModeEAX)
+	}
+	serialized[5] = unknownMode
+
+	p, err := Read(bytes.NewReader(serialized))
+	if err != nil {
+		t.Fatalf("failed to parse: %s", err)
+	}
+
+	ske, ok := p.(*SymmetricKeyEncrypted)
+	if !ok {
+		t.Fatalf("parsed a different packet type: %#v", p)
+	}
+	if ske.Mode != unknownMode {
+		t.Fatalf("SKE AEAD mode is %d (expected %d)", ske.Mode, unknownMode)
+	}
+
+	_, _, err = ske.Decrypt(passphrase)
+	if err == nil {
+		t.Fatal("decrypted an SKE with an unknown AEAD mode")
+	}
+	if _, ok := err.(errors.UnsupportedError); !ok {
+		t.Fatalf("decryption failed with %T (expected errors.UnsupportedError)", err)
+	}
+}
+
 func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 	tests := map[string]CipherFunction{
 		"AES128": CipherAES128,

--- a/openpgp/packet/symmetrically_encrypted_aead.go
+++ b/openpgp/packet/symmetrically_encrypted_aead.go
@@ -68,7 +68,11 @@ func (se *SymmetricallyEncrypted) decryptAead(inputKey []byte) (io.ReadCloser, e
 		return nil, errors.StructuralError(fmt.Sprintf("invalid session key length for cipher: got %d bytes, but expected %d bytes", len(inputKey), se.Cipher.KeySize()))
 	}
 
-	aead, nonce := getSymmetricallyEncryptedAeadInstance(se.Cipher, se.Mode, inputKey, se.Salt[:], se.associatedData())
+	aead, nonce, err := getSymmetricallyEncryptedAeadInstance(se.Cipher, se.Mode, inputKey, se.Salt[:], se.associatedData())
+	if err != nil {
+		return nil, err
+	}
+
 	// Carry the first tagLen bytes
 	chunkSize := decodeAEADChunkSize(se.ChunkSizeByte)
 	tagLen := se.Mode.TagLength()
@@ -131,7 +135,10 @@ func serializeSymmetricallyEncryptedAead(ciphertext io.WriteCloser, cipherSuite 
 		return nil, err
 	}
 
-	aead, nonce := getSymmetricallyEncryptedAeadInstance(cipherSuite.Cipher, cipherSuite.Mode, inputKey, salt, prefix)
+	aead, nonce, err := getSymmetricallyEncryptedAeadInstance(cipherSuite.Cipher, cipherSuite.Mode, inputKey, salt, prefix)
+	if err != nil {
+		return nil, err
+	}
 
 	chunkSize := decodeAEADChunkSize(chunkSizeByte)
 	tagLen := aead.Overhead()
@@ -150,19 +157,22 @@ func serializeSymmetricallyEncryptedAead(ciphertext io.WriteCloser, cipherSuite 
 	}, nil
 }
 
-func getSymmetricallyEncryptedAeadInstance(c CipherFunction, mode AEADMode, inputKey, salt, associatedData []byte) (aead cipher.AEAD, nonce []byte) {
+func getSymmetricallyEncryptedAeadInstance(c CipherFunction, mode AEADMode, inputKey, salt, associatedData []byte) (aead cipher.AEAD, nonce []byte, err error) {
 	hkdfReader := hkdf.New(sha256.New, inputKey, salt, associatedData)
 
 	encryptionKey := make([]byte, c.KeySize())
 	_, _ = readFull(hkdfReader, encryptionKey)
 
+	blockCipher := c.new(encryptionKey)
+	aead, err = mode.new(blockCipher)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	nonce = make([]byte, mode.IvLength())
 
 	// Last 64 bits of nonce are the counter
 	_, _ = readFull(hkdfReader, nonce[:len(nonce)-8])
-
-	blockCipher := c.new(encryptionKey)
-	aead = mode.new(blockCipher)
 
 	return
 }


### PR DESCRIPTION
An unknown AEAD mode in a v5/v6 symmetric-key encrypted session key gives a zero tag length, which later divides by the tag length. This rejects unknown modes during parsing.