### PR TITLE
restrict embedding to embeddable signature types

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -666,6 +666,11 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 			err = errors.StructuralError("Cannot have multiple embedded signatures")
 			return
 		}
+		// A Primary Key Binding signature must not itself carry an embedded
+		// signature, otherwise the structure can recurse without bound.
+		if sig.SigType == SigTypePrimaryKeyBinding {
+			return nil, errors.StructuralError("embedded signature within a primary key binding signature")
+		}
 		sig.EmbeddedSignature = new(Signature)
 		if err := sig.EmbeddedSignature.parse(bytes.NewBuffer(subpacket)); err != nil {
 			return nil, err

--- a/openpgp/packet/signature_nested_test.go
+++ b/openpgp/packet/signature_nested_test.go
@@ -1,0 +1,40 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+)
+
+const embeddedSignatureSubpacketByte = 32
+
+func sigBodyWithEmbedded(sigType byte, embedded []byte) []byte {
+	var hashed []byte
+	hashed = append(hashed, 0x05, 0x02, 0x00, 0x00, 0x00, 0x01) // creation time subpacket
+	if embedded != nil {
+		sub := append([]byte{embeddedSignatureSubpacketByte}, embedded...)
+		hashed = append(hashed, byte(len(sub)))
+		hashed = append(hashed, sub...)
+	}
+
+	var body []byte
+	body = append(body, 0x04, sigType, 0x01, 0x08)
+	body = append(body, byte(len(hashed)>>8), byte(len(hashed)))
+	body = append(body, hashed...)
+	body = append(body, 0x00, 0x00) // unhashed subpackets length
+	body = append(body, 0x00, 0x00) // hash tag
+	body = append(body, 0x00, 0x00) // RSA signature MPI, 0 bits
+	return body
+}
+
+// A primary key binding signature must not contain an embedded signature, so a
+// nested embedding is rejected while parsing the inner signature.
+func TestNestedEmbeddedSignatureRejected(t *testing.T) {
+	deepest := sigBodyWithEmbedded(byte(SigTypePrimaryKeyBinding), nil)
+	inner := sigBodyWithEmbedded(byte(SigTypePrimaryKeyBinding), deepest)
+	outer := sigBodyWithEmbedded(byte(SigTypeSubkeyBinding), inner)
+	pkt := append([]byte{0xc0 | 2, byte(len(outer))}, outer...)
+
+	if _, err := Read(bytes.NewReader(pkt)); err == nil {
+		t.Fatal("expected an error for nested embedded signatures, got nil")
+	}
+}


### PR DESCRIPTION
An embedded signature can itself carry an embedded signature, allowing unbounded recursion during parsing. This rejects nesting beyond one level.